### PR TITLE
Impl version http endpoint

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2579,6 +2579,7 @@ dependencies = [
  "serde_json 1.0.48 (registry+https://github.com/rust-lang/crates.io-index)",
  "structopt 0.3.11 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio 0.2.13 (registry+https://github.com/rust-lang/crates.io-index)",
+ "vergen 3.0.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "warp 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -3380,6 +3381,16 @@ version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
+name = "vergen"
+version = "3.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "bitflags 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "chrono 0.4.10 (registry+https://github.com/rust-lang/crates.io-index)",
+ "failure 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "version_check"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3995,6 +4006,7 @@ dependencies = [
 "checksum utf-8 0.7.5 (registry+https://github.com/rust-lang/crates.io-index)" = "05e42f7c18b8f902290b009cde6d651262f956c98bc51bca4cd1d511c9cd85c7"
 "checksum vcpkg 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)" = "3fc439f2794e98976c88a2a2dafce96b930fe8010b0a256b3c2199a773933168"
 "checksum vec_map 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)" = "05c78687fb1a80548ae3250346c3db86a80a7cdd77bda190189f2d0a0987c81a"
+"checksum vergen 3.0.4 (registry+https://github.com/rust-lang/crates.io-index)" = "6aba5e34f93dc7051dfad05b98a18e9156f27e7b431fe1d2398cb6061c0a1dba"
 "checksum version_check 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "914b1a6776c4c929a602fafd8bc742e06365d4bcbe48c30f9cca5824f70dc9dd"
 "checksum version_check 0.9.1 (registry+https://github.com/rust-lang/crates.io-index)" = "078775d0255232fb988e6fccf26ddc9d1ac274299aaedcedce21c6f72cc533ce"
 "checksum void 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)" = "6a02e4885ed3bc0f2de90ea6dd45ebcbb66dacffe03547fadbb0eeae2770887d"

--- a/http/Cargo.toml
+++ b/http/Cargo.toml
@@ -3,6 +3,10 @@ name = "rust-ipfs-http"
 version = "0.1.0"
 authors = ["Joonas Koivunen <joonas@equilibrium.co>"]
 edition = "2018"
+build = "build.rs"
+
+[build-dependencies]
+vergen = "3.0.4"
 
 [dependencies]
 env_logger = "*"

--- a/http/build.rs
+++ b/http/build.rs
@@ -1,0 +1,9 @@
+fn main() {
+    // vergen will generate build flags which will allow direct usage of env!(...) macro to find
+    // VERGEN_SHA_SHORT and others: https://docs.rs/vergen/3.0.4/vergen/
+    //
+    // the rebuild on each commit can be turned off:
+    // https://docs.rs/vergen/3.0.4/vergen/struct.ConstantsFlags.html#associatedconstant.REBUILD_ON_HEAD_CHANGE
+    vergen::generate_cargo_keys(vergen::ConstantsFlags::all())
+        .expect("Unable to generate the cargo keys!");
+}

--- a/http/src/main.rs
+++ b/http/src/main.rs
@@ -1,4 +1,4 @@
-use serde::Serialize;
+use serde::{Deserialize, Serialize};
 use std::num::NonZeroU16;
 use std::path::PathBuf;
 use structopt::StructOpt;
@@ -188,7 +188,9 @@ fn serve(
         .or(warp::path!("repo" / ..).and_then(not_implemented))
         .or(warp::path!("stats" / ..).and_then(not_implemented))
         .or(warp::path!("swarm" / ..).and_then(not_implemented))
-        .or(warp::path!("version").and_then(not_implemented));
+        .or(warp::path!("version")
+            .and(warp::query::<VersionQuery>())
+            .and_then(version));
 
     let routes = v0.and(api);
     let routes = routes.with(warp::log("rust-ipfs-http-v0"));
@@ -209,6 +211,18 @@ async fn shutdown(
 
 async fn not_implemented() -> Result<impl warp::Reply, std::convert::Infallible> {
     Ok(warp::http::StatusCode::NOT_IMPLEMENTED)
+}
+
+// https://docs-beta.ipfs.io/reference/http/api/#api-v0-version
+// Note: the parameter formatting is only verified, feature looks to be unimplemented for `go-ipfs
+// 0.4.23` and handled by cli. This is not compatible with `rust-ipfs-api`.
+async fn version(_query: VersionQuery) -> Result<impl warp::Reply, std::convert::Infallible> {
+    let response = VersionResponse {
+        version: env!("CARGO_PKG_VERSION"), // TODO: move over to rust-ipfs not to worry about syncing version numbers?
+        commit: env!("VERGEN_SHA_SHORT"),
+    };
+
+    Ok(warp::reply::json(&response))
 }
 
 // NOTE: go-ipfs accepts an -f option for format (unsure if same with Accept: request header),
@@ -248,4 +262,23 @@ struct IdResponse {
     agent_version: &'static str,
     // Multiaddr alike ipfs/0.1.0 ... not sure if there are plans to bump this anytime soon
     protocol_version: &'static str,
+}
+
+/// The /api/v0/version parses but does not change output according to these values in the query
+/// string. Defined in https://docs-beta.ipfs.io/reference/http/api/#api-v0-version. Included here
+/// mostly as experimentation on how to do query parameters.
+#[derive(Debug, Deserialize)]
+struct VersionQuery {
+    number: Option<bool>,
+    commit: Option<bool>,
+    repo: Option<bool>,
+    all: Option<bool>,
+}
+
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "PascalCase")]
+struct VersionResponse {
+    version: &'static str,
+    commit: &'static str,
+    // repo is here for go-ipfs and js-ipfs but we do not have full repo at the moment
 }


### PR DESCRIPTION
Closes #78. Nothing special. I only added here, but was thinking the http module to could move into structure similar to `v0::version::{Query, Response, version}` or `v0::id::{Response, id};`  instead of appending everything to a single endless main.rs :)