### PR TITLE
fix rebased patched dep

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -576,7 +576,7 @@ dependencies = [
 [[package]]
 name = "ctr"
 version = "0.3.2"
-source = "git+https://github.com/koivunej/stream-ciphers.git?branch=ctr128-64to128#3c5a767bd30d17998515df29c93bd50b6486cc66"
+source = "git+https://github.com/koivunej/stream-ciphers.git?branch=ctr128-64to128#51f939820ba5679fe214a6fb863250af78621d08"
 dependencies = [
  "block-cipher-trait 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "stream-cipher 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",


### PR DESCRIPTION
I rebased my PR branch in order to get a new CI run on stream-ciphers, and forgot Cargo.lock was locked into the now-missing commit. This bumps the commit.