### PR TITLE
fix: ci stop using actions/checkout@v1

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -100,7 +100,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Checkout sources
-      uses: actions/checkout@v1
+      uses: actions/checkout@v2
 
     - name: Cache cargo folder
       uses: actions/cache@v1
@@ -124,7 +124,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Checkout sources
-      uses: actions/checkout@v1
+      uses: actions/checkout@v2
 
     - name: Cache cargo folder
       uses: actions/cache@v1


### PR DESCRIPTION
with the https://github.com/ipfs-rust/rust-ipfs/pull/85 there were first some spurious failures on windows (probably transient gh infra issues) and later we noticed that the checkout action on lint-rust and readme-doctest was failing.

I noticed the checkout action on the failing jobs were using an older version of the failing action than the matrix action which succeeded. tried to upgrade that and it worked, didn't look further.