### PR TITLE
RSA keygen in preparation to asking /id from ipfs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,6 +52,7 @@ jobs:
       CARGO_INCREMENTAL: 0
       LLVM_CONFIG_PATH: /usr/local/opt/llvm/bin/llvm-config
       NDK_HOME: /usr/local/lib/android/sdk/ndk-bundle
+      VCPKGRS_DYNAMIC: 1
 
     runs-on: ${{ matrix.platform.host }}
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -67,11 +67,11 @@ jobs:
 
     - name: Install dependencies ubuntu
       if: matrix.platform.host == 'ubuntu-latest'
-      run: sudo apt-get install llvm-dev
+      run: sudo apt-get install llvm-dev openssl-dev pkg-config
 
     - name: Install dependencies macos
       if: matrix.platform.host == 'macos-latest'
-      run: brew install llvm
+      run: brew install llvm openssl
 
     - name: Install dependencies windows
       if: matrix.platform.host == 'windows-latest'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -95,16 +95,22 @@ jobs:
       run: cargo install cargo-ndk
 
     - name: Build
-      if: contains(matrix.platform.target, 'android') == false
-      run: cargo build --all --target ${{ matrix.platform.target }}
+      if: matrix.platform.cross == false
+      run: cargo build --workspace --target ${{ matrix.platform.target }}
 
     - name: Build android
       if: contains(matrix.platform.target, 'android')
-      run: cargo ndk --android-platform 29 --target ${{ matrix.platform.target }} build --all
+      run: cargo ndk --android-platform 29 --target ${{ matrix.platform.target }} build --workspace --exclude http
+      # exclude http on android because openssl
+
+    - name: Build other cross compilations
+      if: contains(matrix.platform.target, 'android') == false && matrix.platform.cross == true
+      run: cargo build --workspace --exclude http
+      # exclude http on other cross compilation targets because openssl
 
     - name: Rust tests
       if: matrix.platform.cross == false
-      run: cargo test --all
+      run: cargo test --workspace
 
   lint-rust:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,6 +31,7 @@ jobs:
         - target: armv7-linux-androideabi
           host: ubuntu-latest
           cross: true
+
         - target: aarch64-linux-android
           host: ubuntu-latest
           cross: true
@@ -38,6 +39,7 @@ jobs:
         - target: armv7-apple-ios
           host: macos-latest
           cross: true
+
         - target: aarch64-apple-ios
           host: macos-latest
           cross: true
@@ -72,7 +74,14 @@ jobs:
 
     - name: Install dependencies windows
       if: matrix.platform.host == 'windows-latest'
-      run: choco install llvm
+      run: |
+        choco install llvm
+        vcpkg integrate install
+        vcpkg install openssl:x64-windows
+        Copy-Item C:\vcpkg\installed\x64-windows\bin\libcrypto-1_1-x64.dll C:\vcpkg\installed\x64-windows\bin\libcrypto.dll
+        Copy-Item C:\vcpkg\installed\x64-windows\bin\libssl-1_1-x64.dll C:\vcpkg\installed\x64-windows\bin\libssl.dll
+        Get-ChildItem C:\vcpkg\installed\x64-windows\bin
+        Get-ChildItem C:\vcpkg\installed\x64-windows\lib
 
     - name: Install rust toolchain
       uses: hecrj/setup-rust-action@v1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -96,16 +96,16 @@ jobs:
 
     - name: Build
       if: matrix.platform.cross == false
-      run: cargo build --workspace --target ${{ matrix.platform.target }}
+      run: cargo build --workspace
 
     - name: Build android
       if: contains(matrix.platform.target, 'android')
-      run: cargo ndk --android-platform 29 --target ${{ matrix.platform.target }} build --workspace --exclude http
+      run: cargo ndk --android-platform 29 --target ${{ matrix.platform.target }} build --workspace --exclude rust-ipfs-http
       # exclude http on android because openssl
 
     - name: Build other cross compilations
       if: contains(matrix.platform.target, 'android') == false && matrix.platform.cross == true
-      run: cargo build --workspace --exclude http
+      run: cargo build --workspace --exclude rust-ipfs-http --target ${{ matrix.platform.target }}
       # exclude http on other cross compilation targets because openssl
 
     - name: Rust tests

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -67,7 +67,7 @@ jobs:
 
     - name: Install dependencies ubuntu
       if: matrix.platform.host == 'ubuntu-latest'
-      run: sudo apt-get install llvm-dev openssl-dev pkg-config
+      run: sudo apt-get install llvm-dev libssl-dev pkg-config
 
     - name: Install dependencies macos
       if: matrix.platform.host == 'macos-latest'

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -822,6 +822,19 @@ version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
+name = "foreign-types"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "foreign-types-shared 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "foreign-types-shared"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
 name = "fuchsia-cprng"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2028,6 +2041,31 @@ version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
+name = "openssl"
+version = "0.10.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "bitflags 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cfg-if 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)",
+ "foreign-types 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.67 (registry+https://github.com/rust-lang/crates.io-index)",
+ "openssl-sys 0.9.54 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "openssl-sys"
+version = "0.9.54"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "autocfg 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cc 1.0.50 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.67 (registry+https://github.com/rust-lang/crates.io-index)",
+ "pkg-config 0.3.17 (registry+https://github.com/rust-lang/crates.io-index)",
+ "vcpkg 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "parity-multiaddr"
 version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2575,9 +2613,14 @@ version = "0.1.0"
 dependencies = [
  "env_logger 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "ipfs 0.1.0",
+ "multibase 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "openssl 0.10.28 (registry+https://github.com/rust-lang/crates.io-index)",
+ "prost 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "prost-build 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.104 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.48 (registry+https://github.com/rust-lang/crates.io-index)",
  "structopt 0.3.11 (registry+https://github.com/rust-lang/crates.io-index)",
+ "thiserror 1.0.11 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio 0.2.13 (registry+https://github.com/rust-lang/crates.io-index)",
  "vergen 3.0.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "warp 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -3386,7 +3429,7 @@ version = "3.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "bitflags 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "chrono 0.4.10 (registry+https://github.com/rust-lang/crates.io-index)",
+ "chrono 0.4.11 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -3745,6 +3788,8 @@ dependencies = [
 "checksum fixedbitset 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "37ab347416e802de484e4d03c7316c48f1ecb56574dfd4a46a80f173ce1de04d"
 "checksum flate2 1.0.13 (registry+https://github.com/rust-lang/crates.io-index)" = "6bd6d6f4752952feb71363cffc9ebac9411b75b87c6ab6058c40c8900cf43c0f"
 "checksum fnv 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)" = "2fad85553e09a6f881f739c29f0b00b0f01357c743266d478b68951ce23285f3"
+"checksum foreign-types 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)" = "f6f339eb8adc052cd2ca78910fda869aefa38d22d5cb648e6485e4d3fc06f3b1"
+"checksum foreign-types-shared 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
 "checksum fuchsia-cprng 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "a06f77d526c1a601b7c4cdd98f54b5eaabffc14d5f2f0296febdc7f357c6d3ba"
 "checksum fuchsia-zircon 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "2e9763c69ebaae630ba35f74888db465e49e259ba1bc0eda7d06f4a067615d82"
 "checksum fuchsia-zircon-sys 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "3dcaa9ae7725d12cdb85b3ad99a434db70b468c09ded17e012d86b5c1010f7a7"
@@ -3856,6 +3901,8 @@ dependencies = [
 "checksum num_cpus 1.12.0 (registry+https://github.com/rust-lang/crates.io-index)" = "46203554f085ff89c235cd12f7075f3233af9b11ed7c9e16dfe2560d03313ce6"
 "checksum once_cell 1.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "b1c601810575c99596d4afc46f78a678c80105117c379eb3650cf99b8a21ce5b"
 "checksum opaque-debug 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)" = "2839e79665f131bdb5782e51f2c6c9599c133c6098982a54c794358bf432529c"
+"checksum openssl 0.10.28 (registry+https://github.com/rust-lang/crates.io-index)" = "973293749822d7dd6370d6da1e523b0d1db19f06c459134c658b2a4261378b52"
+"checksum openssl-sys 0.9.54 (registry+https://github.com/rust-lang/crates.io-index)" = "1024c0a59774200a555087a6da3f253a9095a5f344e353b212ac4c8b8e450986"
 "checksum parity-multiaddr 0.7.3 (registry+https://github.com/rust-lang/crates.io-index)" = "f77055f9e81921a8cc7bebeb6cded3d128931d51f1e3dd6251f0770a6d431477"
 "checksum parity-multihash 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)" = "7a1cd2ba02391b81367bec529fb209019d718684fdc8ad6a712c2b536e46f775"
 "checksum parity-send-wrapper 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "aa9777aa91b8ad9dd5aaa04a9b6bcb02c7f1deb952fca5a66034d5e63afc5c6f"

--- a/http/Cargo.toml
+++ b/http/Cargo.toml
@@ -7,6 +7,7 @@ build = "build.rs"
 
 [build-dependencies]
 vergen = "3.0.4"
+prost-build = "0.6.1"
 
 [dependencies]
 env_logger = "*"
@@ -16,3 +17,10 @@ serde_json = "*"
 structopt = "*"
 tokio = { version = "0.2", features = ["full"] }
 warp = { version = "0.2" }
+thiserror = "1.0"
+multibase = "0.8.0"
+
+# openssl is required for rsa keygen but not used by the rust-ipfs or it's dependencies
+openssl = "0.10"
+
+prost = "0.6.1"

--- a/http/build.rs
+++ b/http/build.rs
@@ -6,4 +6,6 @@ fn main() {
     // https://docs.rs/vergen/3.0.4/vergen/struct.ConstantsFlags.html#associatedconstant.REBUILD_ON_HEAD_CHANGE
     vergen::generate_cargo_keys(vergen::ConstantsFlags::all())
         .expect("Unable to generate the cargo keys!");
+
+    prost_build::compile_protos(&["src/keys.proto"], &["src"]).unwrap();
 }

--- a/http/src/config.rs
+++ b/http/src/config.rs
@@ -59,7 +59,8 @@ fn create(
 
     let bits = bits.get();
 
-    if bits < 1024 || bits > 16 * 1024 {
+    if bits < 2048 || bits > 16 * 1024 {
+        // ring will not accept a less than 2048 key
         return Err(InitializationError::InvalidRsaKeyLength(bits));
     }
 

--- a/http/src/config.rs
+++ b/http/src/config.rs
@@ -261,3 +261,29 @@ struct Identity {
     #[serde(rename = "PrivKey")]
     private_key: String,
 }
+
+#[cfg(test)]
+mod test {
+    #[test]
+    fn pem_to_der_helloworld() {
+        use super::pem_to_der;
+        let input = "-----BEGIN something anything-----
+aGVsbG8gd29ybGQ=
+-----END something anything-----
+
+garbage in the end is ignored";
+
+        assert_eq!(pem_to_der(input.as_bytes()), b"hello world");
+    }
+
+    #[test]
+    #[should_panic]
+    fn pem_to_der_tag_mismatch() {
+        use super::pem_to_der;
+        let input = "-----BEGIN something something-----
+aGVsbG8gd29ybGQ=
+-----END something foobar-----";
+
+        pem_to_der(input.as_bytes());
+    }
+}

--- a/http/src/config.rs
+++ b/http/src/config.rs
@@ -160,7 +160,7 @@ pub fn load(config: File) -> Result<ipfs::Keypair, LoadingError> {
             ipfs::Keypair::rsa_from_pkcs8(&mut pkcs8)
                 .map_err(|e| LoadingError::PrivateKeyLoadingFailed(Box::new(e)))?
         }
-        keytype => return Err(LoadingError::UnsupportedPrivateKeyType(private_key.r#type)),
+        _keytype => return Err(LoadingError::UnsupportedPrivateKeyType(private_key.r#type)),
     };
 
     let peer_id = kp.public().into_peer_id().to_string();

--- a/http/src/config.rs
+++ b/http/src/config.rs
@@ -1,0 +1,203 @@
+//! go-ipfs compatible configuration file handling or at least setup.
+
+use std::fs::{self, File};
+use std::path::Path;
+use std::num::NonZeroU16;
+use thiserror::Error;
+use serde::{Deserialize, Serialize};
+
+/// Temporary module required to de/ser config files base64'd protobuf rsa private key format.
+/// Temporary until accepted into rust-libp2p.
+mod keys_proto {
+    include!(concat!(env!("OUT_DIR"), "/keys_proto.rs"));
+}
+
+/// The way things can go wrong when calling [`initialize`].
+#[derive(Error, Debug)]
+pub enum InitializationError {
+    #[error("repository creation failed: {0}")]
+    DirectoryCreationFailed(std::io::Error),
+    #[error("configuration file creation failed: {0}")]
+    ConfigCreationFailed(std::io::Error),
+    #[error("invalid RSA key length given: {0}")]
+    InvalidRsaKeyLength(u16),
+    #[error("unsupported profiles selected: {0:?}")]
+    InvalidProfiles(Vec<String>),
+    #[error("key generation failed: {0}")]
+    KeyGeneration(Box<dyn std::error::Error + 'static>),
+    #[error("key encoding failed: {0}")]
+    PrivateKeyEncodingFailed(prost::EncodeError),
+    #[error("config serialization failed: {0}")]
+    ConfigWritingFailed(serde_json::Error),
+}
+
+pub fn initialize(ipfs_path: &Path, bits: NonZeroU16, profiles: Vec<String>) -> Result<(), InitializationError> {
+
+    let config_path = ipfs_path.join("config");
+
+    fs::create_dir_all(&ipfs_path)
+        .map_err(InitializationError::DirectoryCreationFailed)
+        .and_then(|_| fs::File::create(&config_path).map_err(InitializationError::ConfigCreationFailed))
+        .and_then(|config_file| create(config_file, bits, profiles))
+}
+
+fn create(config: File, bits: NonZeroU16, profiles: Vec<String>) -> Result<(), InitializationError> {
+    use prost::Message;
+    use multibase::Base::{Base64, Base64Pad};
+    use std::io::BufWriter;
+
+    let bits = bits.get();
+
+    if bits < 1024 || bits > 16 * 1024 {
+        return Err(InitializationError::InvalidRsaKeyLength(bits));
+    }
+
+    if profiles.len() != 1 || profiles[0] != "test" {
+        return Err(InitializationError::InvalidProfiles(profiles));
+    }
+
+    let pk = openssl::rsa::Rsa::generate(bits as u32)
+        .map_err(|e| InitializationError::KeyGeneration(Box::new(e)))?;
+
+    // sadly the pkcs8 to der functions are not yet exposed via the nicer interface
+    // https://github.com/sfackler/rust-openssl/issues/880
+    let pkcs8 = openssl::pkey::PKey::from_rsa(pk.clone())
+        .and_then(|pk| pk.private_key_to_pem_pkcs8())
+        .map_err(|e| InitializationError::KeyGeneration(Box::new(e)))?;
+
+    let mut pkcs8 = pem_to_der(&pkcs8);
+
+    let kp = ipfs::Keypair::rsa_from_pkcs8(&mut pkcs8)
+        .expect("Failed to turn pkcs#8 into libp2p::identity::Keypair");
+
+    let peer_id = kp.public().into_peer_id().to_string();
+
+    println!("Peer id: {}", peer_id);
+
+    let pkcs1 = pk.private_key_to_der()
+        .map_err(|e| InitializationError::KeyGeneration(Box::new(e)))?;
+
+    let key_desc = keys_proto::PrivateKey {
+        r#type: keys_proto::KeyType::Rsa as i32,
+        data: pkcs1,
+    };
+
+    let private_key = {
+        let mut buf = Vec::with_capacity(key_desc.encoded_len());
+        key_desc.encode(&mut buf)
+            .map_err(InitializationError::PrivateKeyEncodingFailed)?;
+        buf
+    };
+
+    let private_key = Base64.encode(&private_key);
+
+    let config_contents = CompatibleConfigFile {
+        identity: Identity {
+            peer_id,
+            private_key,
+        }
+    };
+
+    serde_json::to_writer_pretty(BufWriter::new(config), &config_contents)
+        .map_err(InitializationError::ConfigWritingFailed)?;
+
+    Ok(())
+}
+
+#[derive(Error, Debug)]
+pub enum LoadingError {
+    #[error("failed to open the configuration file: {0}")]
+    ConfigurationFileOpening(std::io::Error),
+    #[error("failed to read the configuration file: {0}")]
+    ConfigurationFileFormat(serde_json::Error),
+    #[error("failed to load the private key: {0}")]
+    PrivateKeyLoadingFailed(Box<std::error::Error + 'static>),
+    #[error("unsupported private key format: {0}")]
+    UnsupportedPrivateKeyType(i32),
+}
+
+pub fn load(config: File) -> Result<ipfs::Keypair, LoadingError> {
+    use prost::Message;
+    use multibase::Base::{Base64, Base64Pad};
+    use std::io::BufReader;
+    use keys_proto::KeyType;
+
+    let CompatibleConfigFile { identity } = serde_json::from_reader(BufReader::new(config))
+        .map_err(LoadingError::ConfigurationFileFormat)?;
+
+    let pk = {
+        let bytes = Base64.decode(identity.private_key)
+            .map_err(|e| LoadingError::PrivateKeyLoadingFailed(Box::new(e)))?;
+
+        let private_key = keys_proto::PrivateKey::decode(bytes.as_slice())
+            .map_err(|e| LoadingError::PrivateKeyLoadingFailed(Box::new(e)))?;
+
+        match KeyType::from_i32(private_key.r#type) {
+            Some(KeyType::Rsa) => {
+                let pk = openssl::rsa::Rsa::private_key_from_der(&private_key.data)
+                    .map_err(|e| LoadingError::PrivateKeyLoadingFailed(Box::new(e)))?;
+
+                let pkcs8 = openssl::pkey::PKey::from_rsa(pk)
+                    .and_then(|pk| pk.private_key_to_pem_pkcs8())
+                    .map_err(|e| LoadingError::PrivateKeyLoadingFailed(Box::new(e)))?;
+
+                let mut pkcs8 = pem_to_der(&pkcs8);
+
+                let kp = ipfs::Keypair::rsa_from_pkcs8(&mut pkcs8)
+                    .expect("Failed to turn pkcs#8 into libp2p::identity::Keypair");
+
+                return Ok(kp);
+            },
+            keytype => return Err(LoadingError::UnsupportedPrivateKeyType(private_key.r#type)),
+        }
+    };
+}
+
+fn pem_to_der(bytes: &[u8]) -> Vec<u8> {
+    use multibase::Base::Base64Pad;
+
+    // Initially tried this with `pem` crate but it will give back bytes for the ascii, but we need
+    // the ascii for multibase's base64pad decoding.
+    let mut base64_encoded = String::new();
+
+    let pem = std::str::from_utf8(&bytes).expect("PEM should be utf8");
+
+    // this will hold the end of the line after -----BEGIN
+    let mut begin_tag = None;
+    let mut found_end_tag = false;
+
+    for line in pem.lines() {
+        if begin_tag.is_none() {
+            assert!(line.starts_with("-----BEGIN"), "Unexpected first line in PEM: {}", line);
+            begin_tag = Some(&line[(5 + 5)..]);
+            continue;
+        }
+
+        if line.starts_with("-----END") {
+            let tag = begin_tag.unwrap();
+
+            assert_eq!(tag, &line[(5 + 3)..], "Unexpected ending in PEM: {}", line);
+            found_end_tag = true;
+            break;
+        }
+
+        base64_encoded.push_str(line);
+    }
+    assert!(found_end_tag, "Failed to parse PEM, failed to find the end tag");
+
+    Base64Pad.decode(base64_encoded)
+        .expect("PEM should contain Base64Pad")
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+#[serde(rename_all = "PascalCase")]
+struct CompatibleConfigFile {
+    identity: Identity,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+#[serde(rename_all = "PascalCase")]
+struct Identity {
+    peer_id: String,
+    private_key: String,
+}

--- a/http/src/config.rs
+++ b/http/src/config.rs
@@ -72,7 +72,8 @@ fn create(config: File, bits: NonZeroU16, profiles: Vec<String>) -> Result<(), I
 
     let peer_id = kp.public().into_peer_id().to_string();
 
-    println!("Peer id: {}", peer_id);
+    // TODO: this part could be PR'd to rust-libp2p as they already have some public key
+    // import/export but probably not if ring does not support these required conversions.
 
     let pkcs1 = pk.private_key_to_der()
         .map_err(|e| InitializationError::KeyGeneration(Box::new(e)))?;

--- a/http/src/keys.proto
+++ b/http/src/keys.proto
@@ -1,0 +1,19 @@
+syntax = "proto2";
+
+package keys_proto;
+
+enum KeyType {
+  RSA = 0;
+  Ed25519 = 1;
+  Secp256k1 = 2;
+}
+
+message PublicKey {
+  required KeyType Type = 1;
+  required bytes Data = 2;
+}
+
+message PrivateKey {
+  required KeyType Type = 1;
+  required bytes Data = 2;
+}

--- a/http/src/lib.rs
+++ b/http/src/lib.rs
@@ -1,0 +1,1 @@
+pub mod v0;

--- a/http/src/lib.rs
+++ b/http/src/lib.rs
@@ -1,1 +1,3 @@
 pub mod v0;
+
+pub mod config;

--- a/http/src/main.rs
+++ b/http/src/main.rs
@@ -74,7 +74,7 @@ fn main() {
             match result {
                 Ok(_) => {
 
-                    std::fs::File::open(home.join("config"))
+                    let kp = std::fs::File::open(config_path)
                         .map_err(config::LoadingError::ConfigurationFileOpening)
                         .and_then(config::load)
                         .unwrap();
@@ -82,7 +82,8 @@ fn main() {
                     // go-ipfs prints here (in addition to earlier "initializing ..."):
                     //
                     // generating {}-bit RSA keypair...done
-                    // peer identity: QmdNmxF88uyUzm8T7ps8LnCuZJzPnJvgUJxpKGqAMuxSQE
+
+                    println!("peer identity: {}", kp.public().into_peer_id());
                     std::process::exit(0);
                 }
                 Err(config::InitializationError::DirectoryCreationFailed(e)) => {

--- a/http/src/main.rs
+++ b/http/src/main.rs
@@ -3,7 +3,7 @@ use std::num::NonZeroU16;
 use std::path::PathBuf;
 use structopt::StructOpt;
 
-use rust_ipfs_http::{v0, config};
+use rust_ipfs_http::{config, v0};
 
 #[derive(Debug, StructOpt)]
 enum Options {
@@ -68,12 +68,10 @@ fn main() {
                 std::process::exit(1);
             }
 
-
             let result = config::initialize(&home, bits, profile);
 
             match result {
                 Ok(_) => {
-
                     let kp = std::fs::File::open(config_path)
                         .map_err(config::LoadingError::ConfigurationFileOpening)
                         .and_then(config::load)
@@ -89,14 +87,14 @@ fn main() {
                 Err(config::InitializationError::DirectoryCreationFailed(e)) => {
                     eprintln!("Error: failed to create repository path {:?}: {}", home, e);
                     std::process::exit(1);
-                },
+                }
                 Err(config::InitializationError::ConfigCreationFailed(_)) => {
                     // this can be any number of errors like permission denied but these are the
                     // strings from go-ipfs
                     eprintln!("Error: ipfs configuration file already exists!");
                     eprintln!("Reinitializing would override your keys.");
                     std::process::exit(1);
-                },
+                }
                 Err(config::InitializationError::InvalidRsaKeyLength(bits)) => {
                     eprintln!("Error: --bits out of range [1024, 16384]: {}", bits);
                     eprintln!("This is a fake version of ipfs cli which does not support much");

--- a/http/src/v0.rs
+++ b/http/src/v0.rs
@@ -1,0 +1,3 @@
+pub mod version;
+
+// pub mod id;

--- a/http/src/v0/version.rs
+++ b/http/src/v0/version.rs
@@ -1,0 +1,32 @@
+use serde::{Deserialize, Serialize};
+
+/// The /api/v0/version parses but does not change output according to these values in the query
+/// string. Defined in https://docs-beta.ipfs.io/reference/http/api/#api-v0-version. Included here
+/// mostly as experimentation on how to do query parameters.
+#[derive(Debug, Deserialize)]
+pub struct Query {
+    number: Option<bool>,
+    commit: Option<bool>,
+    repo: Option<bool>,
+    all: Option<bool>,
+}
+
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "PascalCase")]
+pub struct Response {
+    version: &'static str,
+    commit: &'static str,
+    // repo is here for go-ipfs and js-ipfs but we do not have full repo at the moment
+}
+
+// https://docs-beta.ipfs.io/reference/http/api/#api-v0-version
+// Note: the parameter formatting is only verified, feature looks to be unimplemented for `go-ipfs
+// 0.4.23` and handled by cli. This is not compatible with `rust-ipfs-api`.
+pub async fn version(_query: Query) -> Result<impl warp::Reply, std::convert::Infallible> {
+    let response = Response {
+        version: env!("CARGO_PKG_VERSION"), // TODO: move over to rust-ipfs not to worry about syncing version numbers?
+        commit: env!("VERGEN_SHA_SHORT"),
+    };
+
+    Ok(warp::reply::json(&response))
+}

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,4 +1,4 @@
-use libp2p::identity::{Keypair, PublicKey};
+use libp2p::identity::Keypair;
 use libp2p::multiaddr::Protocol;
 use libp2p::{Multiaddr, PeerId};
 use rand::{rngs::OsRng, Rng};
@@ -65,7 +65,7 @@ impl fmt::Debug for KeyMaterial {
                 } else {
                     write!(fmt, "Rsa(not loaded: {:?})", filename)
                 }
-            }
+            },
         }
     }
 }
@@ -84,13 +84,9 @@ impl KeyMaterial {
                 .map(|kp| Keypair::Ed25519(kp.as_ref().clone())),
             KeyMaterial::RsaPkcs8File { ref keypair, .. } => {
                 keypair.as_ref().map(|kp| Keypair::Rsa(kp.as_ref().clone()))
-            }
+            },
         }
         .expect("KeyMaterial needs to be loaded before accessing the keypair")
-    }
-
-    fn public(&self) -> PublicKey {
-        self.clone_keypair().public()
     }
 
     fn load(&mut self) -> Result<(), KeyMaterialLoadingFailure> {
@@ -115,7 +111,7 @@ impl KeyMaterial {
                 let kp = libp2p::identity::rsa::Keypair::from_pkcs8(&mut bytes)
                     .map_err(KeyMaterialLoadingFailure::RsaDecoding)?;
                 *keypair = Some(Box::new(kp));
-            }
+            },
             _ => { /* all set */ }
         }
 
@@ -161,10 +157,6 @@ impl ConfigFile {
 
     pub fn secio_key_pair(&self) -> Keypair {
         self.key.clone_keypair()
-    }
-
-    pub fn peer_id(&self) -> PeerId {
-        self.key.public().into_peer_id()
     }
 
     pub fn bootstrap(&self) -> Vec<(Multiaddr, PeerId)> {

--- a/src/config.rs
+++ b/src/config.rs
@@ -65,7 +65,7 @@ impl fmt::Debug for KeyMaterial {
                 } else {
                     write!(fmt, "Rsa(not loaded: {:?})", filename)
                 }
-            },
+            }
         }
     }
 }
@@ -84,7 +84,7 @@ impl KeyMaterial {
                 .map(|kp| Keypair::Ed25519(kp.as_ref().clone())),
             KeyMaterial::RsaPkcs8File { ref keypair, .. } => {
                 keypair.as_ref().map(|kp| Keypair::Rsa(kp.as_ref().clone()))
-            },
+            }
         }
         .expect("KeyMaterial needs to be loaded before accessing the keypair")
     }
@@ -111,7 +111,7 @@ impl KeyMaterial {
                 let kp = libp2p::identity::rsa::Keypair::from_pkcs8(&mut bytes)
                     .map_err(KeyMaterialLoadingFailure::RsaDecoding)?;
                 *keypair = Some(Box::new(kp));
-            },
+            }
             _ => { /* all set */ }
         }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -107,12 +107,12 @@ impl<Types: IpfsTypes> IpfsOptions<Types> {
         }
     }
 
-    fn secio_key_pair(&self) -> libp2p::identity::Keypair {
-        self.keypair.clone()
+    fn secio_key_pair(&self) -> &Keypair {
+        &self.keypair
     }
 
-    fn bootstrap(&self) -> Vec<(Multiaddr, PeerId)> {
-        self.bootstrap.clone()
+    fn bootstrap(&self) -> &[(Multiaddr, PeerId)] {
+        &self.bootstrap
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -12,7 +12,7 @@ use async_std::path::PathBuf;
 use futures::channel::mpsc::{channel, Receiver, Sender};
 use libipld::cid::Codec;
 pub use libipld::ipld::Ipld;
-pub use libp2p::{Multiaddr, PeerId, identity::Keypair};
+pub use libp2p::{identity::Keypair, Multiaddr, PeerId};
 use std::future::Future;
 use std::marker::PhantomData;
 
@@ -104,7 +104,7 @@ impl<Types: IpfsTypes> IpfsOptions<Types> {
             ipfs_log: String::from("trace"),
             ipfs_path,
             keypair,
-            bootstrap
+            bootstrap,
         }
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -13,6 +13,7 @@ use futures::channel::mpsc::{channel, Receiver, Sender};
 use libipld::cid::Codec;
 pub use libipld::ipld::Ipld;
 pub use libp2p::{identity::Keypair, Multiaddr, PeerId};
+use std::fmt;
 use std::future::Future;
 use std::marker::PhantomData;
 
@@ -84,8 +85,6 @@ pub struct IpfsOptions<Types: IpfsTypes> {
     /// Nodes dialed during startup
     pub bootstrap: Vec<(Multiaddr, PeerId)>,
 }
-
-use std::fmt;
 
 impl<Types: IpfsTypes> fmt::Debug for IpfsOptions<Types> {
     fn fmt(&self, fmt: &mut fmt::Formatter<'_>) -> fmt::Result {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -12,7 +12,7 @@ use async_std::path::PathBuf;
 use futures::channel::mpsc::{channel, Receiver, Sender};
 use libipld::cid::Codec;
 pub use libipld::ipld::Ipld;
-pub use libp2p::PeerId;
+pub use libp2p::{Multiaddr, PeerId, identity::Keypair};
 use std::future::Future;
 use std::marker::PhantomData;
 

--- a/src/p2p/mod.rs
+++ b/src/p2p/mod.rs
@@ -25,9 +25,9 @@ pub struct SwarmOptions<TSwarmTypes: SwarmTypes> {
 
 impl<TSwarmTypes: SwarmTypes> From<&IpfsOptions<TSwarmTypes>> for SwarmOptions<TSwarmTypes> {
     fn from(options: &IpfsOptions<TSwarmTypes>) -> Self {
-        let key_pair = options.secio_key_pair();
+        let key_pair = options.secio_key_pair().clone();
         let peer_id = key_pair.public().into_peer_id();
-        let bootstrap = options.bootstrap();
+        let bootstrap = options.bootstrap().to_vec();
         SwarmOptions {
             _marker: PhantomData,
             key_pair,

--- a/src/p2p/mod.rs
+++ b/src/p2p/mod.rs
@@ -25,9 +25,9 @@ pub struct SwarmOptions<TSwarmTypes: SwarmTypes> {
 
 impl<TSwarmTypes: SwarmTypes> From<&IpfsOptions<TSwarmTypes>> for SwarmOptions<TSwarmTypes> {
     fn from(options: &IpfsOptions<TSwarmTypes>) -> Self {
-        let key_pair = options.config.secio_key_pair();
+        let key_pair = options.secio_key_pair();
         let peer_id = key_pair.public().into_peer_id();
-        let bootstrap = options.config.bootstrap();
+        let bootstrap = options.bootstrap();
         SwarmOptions {
             _marker: PhantomData,
             key_pair,


### PR DESCRIPTION
Sorry for the refactoring with the http being here as well, I created a config module with configuration file handling there. The `rsa` keygen and following import/export thing was a lot more difficult than I thought.

I made some questionable changes to `ipfs::config` as well, I removed it from the `ifps::IpfsOptions`. I made this because looking back at the `ipfs::config::KeyMaterial` it seems like a bad idea to extend it with `Pkcs8Buffer` or something similar, I am not so sure if the mutability through `Option`s makes a lot of sense. If this solution feels worse I can present the `KeyMaterial` extension as well. I also thought that the "library initialization through configuration file" might not be so important use case after all, as most likely you'd like to bring your application configuration file and turn that into the `ipfs::IpfsOptions`.

This could be mergeable as is. I'll continue from here into spawning the background task and exposing the `ipfs::Ipfs` to the filters, but hopefully on a different PR.