### PR TITLE
Expose actual local /id

### DIFF
--- a/examples/client1.rs
+++ b/examples/client1.rs
@@ -20,6 +20,6 @@ fn main() {
         let root = ipld!([res1.unwrap(), res2.unwrap()]);
         ipfs.put_dag(root).await.unwrap();
 
-        ipfs.exit_daemon();
+        ipfs.exit_daemon().await;
     });
 }

--- a/examples/client2.rs
+++ b/examples/client2.rs
@@ -21,6 +21,6 @@ fn main() {
         println!("Received block with contents: {:?}", res1.unwrap());
         println!("Received block with contents: {:?}", res2.unwrap());
 
-        ipfs.exit_daemon();
+        ipfs.exit_daemon().await;
     });
 }

--- a/examples/ipfs_bitswap_test.rs
+++ b/examples/ipfs_bitswap_test.rs
@@ -37,5 +37,7 @@ fn main() {
         let file = ipfs.get(path).await.unwrap();
         let contents: String = file.into();
         println!("file contents: {:?}", contents);
+
+        ipfs.exit_daemon().await;
     });
 }

--- a/examples/ipfs_ipns_test.rs
+++ b/examples/ipfs_ipns_test.rs
@@ -34,6 +34,6 @@ fn main() {
         let ipfs_path = ipfs.resolve_ipns(&ipfs_path).await.unwrap();
         println!("Resolved stage 2: {:?}", ipfs_path.to_string());
 
-        ipfs.exit_daemon();
+        ipfs.exit_daemon().await;
     });
 }

--- a/http/src/config.rs
+++ b/http/src/config.rs
@@ -65,6 +65,10 @@ fn create(
     }
 
     if profiles.len() != 1 || profiles[0] != "test" {
+        // profiles are expected to be (comma separated) "test" as there are no bootstrap peer
+        // handling yet. the conformance test cases seem to init `go-ipfs` in this profile where
+        // it does not have any bootstrap nodes, and multi node tests later call swarm apis to
+        // dial the nodes together.
         return Err(InitializationError::InvalidProfiles(profiles));
     }
 

--- a/http/src/main.rs
+++ b/http/src/main.rs
@@ -2,6 +2,8 @@ use std::num::NonZeroU16;
 use std::path::PathBuf;
 use structopt::StructOpt;
 
+use warp::query;
+
 use ipfs::{Ipfs, IpfsOptions, IpfsTypes, UninitializedIpfs};
 use rust_ipfs_http::{config, v0};
 
@@ -133,11 +135,8 @@ fn main() {
     let mut rt = tokio::runtime::Runtime::new().expect("Failed to create event loop");
 
     rt.block_on(async move {
-
-        let opts: IpfsOptions<ipfs::TestTypes> = IpfsOptions::new(
-            home.clone().into(),
-            keypair,
-            Vec::new());
+        let opts: IpfsOptions<ipfs::TestTypes> =
+            IpfsOptions::new(home.clone().into(), keypair, Vec::new());
 
         let (ipfs, task) = UninitializedIpfs::new(opts)
             .await
@@ -200,7 +199,7 @@ fn serve<Types: IpfsTypes>(
     let api = shutdown
         .or(warp::path!("id")
             .and(with_ipfs(ipfs))
-            .and(warp::query::<v0::id::Query>())
+            .and(query::<v0::id::Query>())
             .and_then(v0::id::identity))
         // Placeholder paths
         // https://docs.rs/warp/0.2.2/warp/macro.path.html#path-prefixes
@@ -222,20 +221,20 @@ fn serve<Types: IpfsTypes>(
         .or(warp::path!("repo" / ..).and_then(not_implemented))
         .or(warp::path!("stats" / ..).and_then(not_implemented))
         .or(warp::path!("swarm" / "connect")
-            .and(warp::query::<v0::swarm::ConnectQuery>())
+            .and(query::<v0::swarm::ConnectQuery>())
             .and_then(v0::swarm::connect))
         .or(warp::path!("swarm" / "peers")
-            .and(warp::query::<v0::swarm::PeersQuery>())
+            .and(query::<v0::swarm::PeersQuery>())
             .and_then(v0::swarm::peers))
         .or(warp::path!("swarm" / "addrs").and_then(v0::swarm::addrs))
         .or(warp::path!("swarm" / "addrs" / "local")
-            .and(warp::query::<v0::swarm::AddrsLocalQuery>())
+            .and(query::<v0::swarm::AddrsLocalQuery>())
             .and_then(v0::swarm::addrs_local))
         .or(warp::path!("swarm" / "disconnect")
-            .and(warp::query::<v0::swarm::DisconnectQuery>())
+            .and(query::<v0::swarm::DisconnectQuery>())
             .and_then(v0::swarm::disconnect))
         .or(warp::path!("version")
-            .and(warp::query::<v0::version::Query>())
+            .and(query::<v0::version::Query>())
             .and_then(v0::version::version));
 
     let routes = v0.and(api);

--- a/http/src/v0.rs
+++ b/http/src/v0.rs
@@ -1,3 +1,47 @@
-pub mod version;
-// pub mod id;
+use serde::Serialize;
+use std::borrow::Cow;
+
+pub mod id;
 pub mod swarm;
+pub mod version;
+
+/// The common responses apparently returned by the go-ipfs HTTP api on errors.
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "PascalCase")]
+pub struct MessageResponse {
+    message: Cow<'static, str>,
+    code: usize,
+    r#type: MessageKind,
+}
+
+impl MessageResponse {
+    fn to_json_reply(&self) -> warp::reply::Json {
+        warp::reply::json(self)
+    }
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub enum MessageKind {
+    Error,
+}
+
+impl MessageKind {
+    // FIXME: haven't found a spec for these codes yet
+    pub fn with_code(self, code: usize) -> MessageResponseBuilder {
+        MessageResponseBuilder(self, code)
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct MessageResponseBuilder(MessageKind, usize);
+
+impl MessageResponseBuilder {
+    pub fn with_message<S: Into<Cow<'static, str>>>(self, message: S) -> MessageResponse {
+        let Self(kind, code) = self;
+        MessageResponse {
+            message: message.into(),
+            code,
+            r#type: kind,
+        }
+    }
+}

--- a/http/src/v0.rs
+++ b/http/src/v0.rs
@@ -6,6 +6,7 @@ pub mod swarm;
 pub mod version;
 
 /// The common responses apparently returned by the go-ipfs HTTP api on errors.
+/// See also: https://github.com/ferristseng/rust-ipfs-api/blob/master/ipfs-api/src/response/error.rs
 #[derive(Debug, Serialize)]
 #[serde(rename_all = "PascalCase")]
 pub struct MessageResponse {
@@ -20,6 +21,7 @@ impl MessageResponse {
     }
 }
 
+/// The `MessageResponse` has this field, unsure if it can be anything other than "error".
 #[derive(Debug, Clone, Serialize)]
 pub enum MessageKind {
     Error,
@@ -32,6 +34,8 @@ impl MessageKind {
     }
 }
 
+/// Combining `MessageKind` and `code` using `MessageKind::with_code` returns a
+/// `MessageResponseBuilder` which will only need a message to become `MessageResponse`.
 #[derive(Debug, Clone)]
 pub struct MessageResponseBuilder(MessageKind, usize);
 

--- a/http/src/v0/id.rs
+++ b/http/src/v0/id.rs
@@ -1,0 +1,89 @@
+use super::MessageKind;
+use ipfs::{Ipfs, IpfsTypes, PeerId};
+use serde::{Deserialize, Serialize};
+
+// NOTE: go-ipfs accepts an -f option for format (unsure if same with Accept: request header),
+// unsure on what values -f takes, since `go-ipfs` seems to just print the value back? With plain http
+// requests the `f` or `format` is ignored. Perhaps it's a cli functionality. This should return a
+// json body, which does get pretty formatted by the cli.
+//
+// FIXME: Reference has argument `arg: PeerId` which does get processed.
+//
+// https://docs.ipfs.io/reference/api/http/#api-v0-id
+pub async fn identity<T: IpfsTypes>(
+    ipfs: Ipfs<T>,
+    query: Query,
+) -> Result<Box<dyn warp::Reply>, warp::Rejection> {
+    use multibase::Base::Base64Pad;
+    use std::str::FromStr;
+
+    if let Some(peer_id) = query.arg {
+        match PeerId::from_str(&peer_id) {
+            Ok(_) => {
+                // FIXME: probably find this peer, if a match, use identify protocol
+                return Ok(Box::new(warp::http::StatusCode::NOT_IMPLEMENTED));
+            }
+            Err(_) => {
+                // FIXME: we need to customize the query deserialization error
+                return Ok(Box::new(warp::reply::with_status(
+                    MessageKind::Error
+                        .with_code(0)
+                        .with_message("invalid peer id")
+                        .to_json_reply(),
+                    warp::http::StatusCode::INTERNAL_SERVER_ERROR,
+                )));
+            }
+        }
+    }
+
+    match ipfs.identity().await {
+        Ok((public_key, addresses)) => {
+            let id = public_key.clone().into_peer_id().to_string();
+            let public_key = Base64Pad.encode(public_key.into_protobuf_encoding());
+
+            let response = Response {
+                id,
+                public_key,
+                addresses: addresses.into_iter().map(|addr| addr.to_string()).collect(),
+                agent_version: "rust-ipfs/0.1.0",
+                protocol_version: "ipfs/0.1.0",
+            };
+
+            // TODO: investigate how this could be avoided, perhaps by making the ipfs::Error a
+            // Reject
+            Ok(Box::new(warp::reply::json(&response)))
+        }
+        Err(e) => Ok(Box::new(warp::reply::with_status(
+            MessageKind::Error
+                .with_code(0)
+                .with_message(e.to_string())
+                .to_json_reply(),
+            warp::http::StatusCode::INTERNAL_SERVER_ERROR,
+        ))),
+    }
+}
+
+/// Query string of /api/v0/id?arg=peerid&format=notsure
+#[derive(Debug, Deserialize)]
+pub struct Query {
+    // the peer id to query
+    arg: Option<String>,
+    // this does not seem to be reacted to by go-ipfs
+    format: Option<String>,
+}
+
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "PascalCase")]
+struct Response {
+    // PeerId
+    #[serde(rename = "ID")]
+    id: String,
+    // looks like Base64
+    public_key: String,
+    // Multiaddrs
+    addresses: Vec<String>,
+    // Multiaddr alike <agent_name>/<version>, like rust-ipfs/0.0.1
+    agent_version: &'static str,
+    // Multiaddr alike ipfs/0.1.0 ... not sure if there are plans to bump this anytime soon
+    protocol_version: &'static str,
+}


### PR DESCRIPTION
1. fix back https://github.com/ipfs-rust/rust-ipfs/pull/99#discussion_r392204494
2. do a simple query for swarm for `/id` local part

Same as with any `warp::query` at the moment, the error handling needs to be improved and get away from the `Box<dyn warp::Reply>` kind of handling. Unsure yet what'd entail.

Communication with the swarm is done through `IpfsEvent` extending which allows us to get a oneshot sender over to the background task to report back. This is handled privately so we are not at least linking this to the public api. Currently returns 501 not implemented for `/id?arg=another_peerid`.