### PR TITLE
Rename http crate and create it a readme

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -100,12 +100,12 @@ jobs:
 
     - name: Build android
       if: contains(matrix.platform.target, 'android')
-      run: cargo ndk --android-platform 29 --target ${{ matrix.platform.target }} build --workspace --exclude rust-ipfs-http
+      run: cargo ndk --android-platform 29 --target ${{ matrix.platform.target }} build --workspace --exclude ipfs-http
       # exclude http on android because openssl
 
     - name: Build other cross compilations
       if: contains(matrix.platform.target, 'android') == false && matrix.platform.cross == true
-      run: cargo build --workspace --exclude rust-ipfs-http --target ${{ matrix.platform.target }}
+      run: cargo build --workspace --exclude ipfs-http --target ${{ matrix.platform.target }}
       # exclude http on other cross compilation targets because openssl
 
     - name: Rust tests

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1242,6 +1242,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "ipfs-http"
+version = "0.1.0"
+dependencies = [
+ "env_logger 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "futures 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "ipfs 0.1.0",
+ "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "multibase 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "openssl 0.10.28 (registry+https://github.com/rust-lang/crates.io-index)",
+ "prost 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "prost-build 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.104 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_json 1.0.48 (registry+https://github.com/rust-lang/crates.io-index)",
+ "structopt 0.3.11 (registry+https://github.com/rust-lang/crates.io-index)",
+ "thiserror 1.0.11 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio 0.2.13 (registry+https://github.com/rust-lang/crates.io-index)",
+ "vergen 3.0.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "warp 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "ipnet"
 version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2632,27 +2653,6 @@ dependencies = [
  "blake2b_simd 0.5.10 (registry+https://github.com/rust-lang/crates.io-index)",
  "constant_time_eq 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "crossbeam-utils 0.7.2 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "rust-ipfs-http"
-version = "0.1.0"
-dependencies = [
- "env_logger 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "futures 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "ipfs 0.1.0",
- "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "multibase 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "openssl 0.10.28 (registry+https://github.com/rust-lang/crates.io-index)",
- "prost 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "prost-build 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 1.0.104 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde_json 1.0.48 (registry+https://github.com/rust-lang/crates.io-index)",
- "structopt 0.3.11 (registry+https://github.com/rust-lang/crates.io-index)",
- "thiserror 1.0.11 (registry+https://github.com/rust-lang/crates.io-index)",
- "tokio 0.2.13 (registry+https://github.com/rust-lang/crates.io-index)",
- "vergen 3.0.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "warp 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]

--- a/http/Cargo.toml
+++ b/http/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "rust-ipfs-http"
+name = "ipfs-http"
 version = "0.1.0"
 authors = ["Joonas Koivunen <joonas@equilibrium.co>"]
 edition = "2018"

--- a/http/README.md
+++ b/http/README.md
@@ -1,0 +1,14 @@
+# ipfs-http crate
+
+HTTP api on top of ipfs crate. The end binary has some rudimentary ipfs CLI
+functionality but mostly in the aim of testing the `rust-ipfs` via:
+
+ * [ipfs-rust-conformance](https://github.com/ipfs-rust/ipfs-rust-conformance)
+ * [interop](https://github.com/ipfs-rust/interop/)
+
+HTTP specs:
+
+ * https://docs.ipfs.io/reference/api/http/
+
+Status: Pre-alpha, most of the functionality is missing or `501 Not
+Implemented`. See the repository level README for more information.

--- a/http/src/main.rs
+++ b/http/src/main.rs
@@ -3,7 +3,7 @@ use std::path::PathBuf;
 use structopt::StructOpt;
 
 use ipfs::{Ipfs, IpfsOptions, IpfsTypes, UninitializedIpfs};
-use rust_ipfs_http::{config, v0};
+use ipfs_http::{config, v0};
 
 #[derive(Debug, StructOpt)]
 enum Options {


### PR DESCRIPTION
Renames the `rust-ipfs-http` into `ipfs-http`, even though we might want to hold off publishing the crate until someone decides to need it. Also written a small README on the purpose of `ipfs-http`.

This will cause a small conflict with my other two PR's but I can take care of that.