### PR TITLE
fix: both crate names were wrong by default RUST_LOG

### DIFF
--- a/http/src/main.rs
+++ b/http/src/main.rs
@@ -25,7 +25,7 @@ fn main() {
     if std::env::var_os("RUST_LOG").is_none() {
         // FIXME: see if tracing could be used as the frontend for log macros
         // FIXME: use log macros here as well
-        std::env::set_var("RUST_LOG", "rust-ipfs-http=trace,rust-ipfs=trace");
+        std::env::set_var("RUST_LOG", "ipfs-http=trace,ipfs=trace");
     }
 
     env_logger::init();


### PR DESCRIPTION
This is a leftover from PR #103.