### PR TITLE
refactor: remove needless spawning

### DIFF
--- a/src/subscription.rs
+++ b/src/subscription.rs
@@ -4,6 +4,7 @@ use core::fmt::Debug;
 use core::hash::Hash;
 use core::pin::Pin;
 use std::collections::HashMap;
+use std::fmt;
 use std::sync::{Arc, Mutex};
 
 #[derive(Debug)]
@@ -89,6 +90,16 @@ impl<TResult: Clone> Future for SubscriptionFuture<TResult> {
             subscription.add_waker(context.waker().clone());
             Poll::Pending
         }
+    }
+}
+
+impl<TResult> fmt::Debug for SubscriptionFuture<TResult> {
+    fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
+        write!(
+            fmt,
+            "SubscriptionFuture<{}>",
+            std::any::type_name::<TResult>()
+        )
     }
 }
 


### PR DESCRIPTION
The spawning is not needed as the future can be returned as is. I think it's beneficial to limit the concurrent number of things to "incoming concurrency" if at all possible so that the system remains debuggable.

I think the error path could be simplified, not sure why not just make it an anyhow::Error near the source with `format_err!`...?