### PR TITLE
Add pubsub api

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -397,6 +397,9 @@ impl<Types: IpfsTypes> Ipfs<Types> {
         rx.await?
     }
 
+    /// Returns the local node public key and the listened and externally visible addresses.
+    ///
+    /// Public key can be converted to [`PeerId`].
     pub async fn identity(&self) -> Result<(PublicKey, Vec<Multiaddr>), Error> {
         let (tx, rx) = oneshot_channel();
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -613,7 +613,7 @@ pub use node::Node;
 mod node {
     use super::{Ipfs, IpfsOptions, TestTypes, UninitializedIpfs};
 
-    /// Node encapsulates everything to setup a testing instance so that things become easier.
+    /// Node encapsulates everything to setup a testing instance so that multi-node tests become easier.
     pub struct Node {
         ipfs: Ipfs<TestTypes>,
         background_task: async_std::task::JoinHandle<()>,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -465,6 +465,7 @@ impl<Types: IpfsTypes> Ipfs<Types> {
         Ok(rx.await?)
     }
 
+    /// Returns all currently subscribed topics
     pub async fn pubsub_subscribed(&self) -> Result<Vec<String>, Error> {
         let (tx, rx) = oneshot_channel();
 
@@ -613,7 +614,8 @@ pub use node::Node;
 mod node {
     use super::{Ipfs, IpfsOptions, TestTypes, UninitializedIpfs};
 
-    /// Node encapsulates everything to setup a testing instance so that multi-node tests become easier.
+    /// Node encapsulates everything to setup a testing instance so that multi-node tests become
+    /// easier.
     pub struct Node {
         ipfs: Ipfs<TestTypes>,
         background_task: async_std::task::JoinHandle<()>,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -575,7 +575,8 @@ impl<Types: SwarmTypes> Future for IpfsFuture<Types> {
                     let _ = ret.send(self.swarm.as_mut().unsubscribe(topic));
                 }
                 IpfsEvent::PubsubPublish(topic, data, ret) => {
-                    let _ = ret.send(self.swarm.as_mut().publish(topic, data));
+                    self.swarm.as_mut().publish(topic, data);
+                    let _ = ret.send(());
                 }
                 IpfsEvent::PubsubPeers(Some(topic), ret) => {
                     let topic = libp2p::floodsub::Topic::new(topic);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -411,7 +411,7 @@ impl<Types: IpfsTypes> Ipfs<Types> {
     /// Subscribes to a given topic. Can be done at most once without unsubscribing in the between.
     /// Unsubscription can happen automatically after dropping the receiver and failing to send a
     /// message over using it's corresponding sender.
-    pub async fn pubsub_subscribe(&self, topic: &str) -> Result<impl futures::stream::Stream<Item = Arc<PubsubMessage>>, Error> {
+    pub async fn pubsub_subscribe(&self, topic: &str) -> Result<impl futures::stream::Stream<Item = Arc<PubsubMessage>> + fmt::Debug, Error> {
         let (tx, rx) = oneshot_channel();
 
         self.to_task

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -221,7 +221,7 @@ enum IpfsEvent {
     Disconnect(Multiaddr, Channel<()>),
     /// Request background task to return the listened and external addresses
     GetAddresses(OneshotSender<Vec<Multiaddr>>),
-    PubsubSubscribe(String, OneshotSender<Option<futures::channel::mpsc::UnboundedReceiver<Arc<PubsubMessage>>>>),
+    PubsubSubscribe(String, OneshotSender<Option<p2p::pubsub::StreamImpl>>),
     PubsubUnsubscribe(String, OneshotSender<bool>),
     PubsubPublish(String, Vec<u8>, OneshotSender<()>),
     PubsubPeers(Option<String>, OneshotSender<Vec<PeerId>>),
@@ -409,8 +409,8 @@ impl<Types: IpfsTypes> Ipfs<Types> {
     }
 
     /// Subscribes to a given topic. Can be done at most once without unsubscribing in the between.
-    /// Unsubscription can happen automatically after dropping the receiver and failing to send a
-    /// message over using it's corresponding sender.
+    /// The subscription can be unsubscribed by dropping the stream or calling
+    /// [`pubsub_unsubscribe`].
     pub async fn pubsub_subscribe(&self, topic: &str) -> Result<impl futures::stream::Stream<Item = Arc<PubsubMessage>> + fmt::Debug, Error> {
         let (tx, rx) = oneshot_channel();
 

--- a/src/p2p/behaviour.rs
+++ b/src/p2p/behaviour.rs
@@ -1,5 +1,5 @@
-use super::swarm::{Connection, Disconnector, SwarmApi};
 use super::pubsub::Pubsub;
+use super::swarm::{Connection, Disconnector, SwarmApi};
 use crate::p2p::{SwarmOptions, SwarmTypes};
 use crate::repo::Repo;
 use crate::subscription::SubscriptionFuture;

--- a/src/p2p/mod.rs
+++ b/src/p2p/mod.rs
@@ -11,7 +11,7 @@ use std::sync::Arc;
 mod behaviour;
 mod swarm;
 mod transport;
-mod pubsub;
+pub(crate) mod pubsub;
 pub use pubsub::PubsubMessage;
 
 pub use swarm::Connection;

--- a/src/p2p/mod.rs
+++ b/src/p2p/mod.rs
@@ -11,6 +11,8 @@ use std::sync::Arc;
 mod behaviour;
 mod swarm;
 mod transport;
+mod pubsub;
+pub use pubsub::PubsubMessage;
 
 pub use swarm::Connection;
 

--- a/src/p2p/mod.rs
+++ b/src/p2p/mod.rs
@@ -9,9 +9,9 @@ use libp2p::{Multiaddr, PeerId};
 use std::sync::Arc;
 
 mod behaviour;
+pub(crate) mod pubsub;
 mod swarm;
 mod transport;
-pub(crate) mod pubsub;
 pub use pubsub::PubsubMessage;
 
 pub use swarm::Connection;

--- a/src/p2p/pubsub.rs
+++ b/src/p2p/pubsub.rs
@@ -306,7 +306,12 @@ impl NetworkBehaviour for Pubsub {
                 match self.peers.entry(peer_id) {
                     Entry::Occupied(mut oe) => {
                         let topics = oe.get_mut();
-                        topics.retain(|t| t != &topic);
+                        if let Some(pos) = topics.iter().position(|t| t == &topic) {
+                            topics.swap_remove(pos);
+                        }
+                        if topics.is_empty() {
+                            oe.remove();
+                        }
                     }
                     _ => {}
                 }

--- a/src/p2p/pubsub.rs
+++ b/src/p2p/pubsub.rs
@@ -348,7 +348,6 @@ impl NetworkBehaviour for Pubsub {
                     return Poll::Ready(NetworkBehaviourAction::DialPeer { peer_id });
                 }
                 NetworkBehaviourAction::SendEvent { peer_id, event } => {
-                    log::debug!("SendEvent {{ {}, {:?} }}", peer_id, event);
                     return Poll::Ready(NetworkBehaviourAction::SendEvent { peer_id, event });
                 }
                 NetworkBehaviourAction::ReportObservedAddr { address } => {

--- a/src/p2p/pubsub.rs
+++ b/src/p2p/pubsub.rs
@@ -303,17 +303,14 @@ impl NetworkBehaviour for Pubsub {
                 peer_id,
                 topic,
             }) => {
-                match self.peers.entry(peer_id) {
-                    Entry::Occupied(mut oe) => {
-                        let topics = oe.get_mut();
-                        if let Some(pos) = topics.iter().position(|t| t == &topic) {
-                            topics.swap_remove(pos);
-                        }
-                        if topics.is_empty() {
-                            oe.remove();
-                        }
+                if let Entry::Occupied(mut oe) = self.peers.entry(peer_id) {
+                    let topics = oe.get_mut();
+                    if let Some(pos) = topics.iter().position(|t| t == &topic) {
+                        topics.swap_remove(pos);
                     }
-                    _ => {}
+                    if topics.is_empty() {
+                        oe.remove();
+                    }
                 }
 
                 Poll::Pending

--- a/src/p2p/pubsub.rs
+++ b/src/p2p/pubsub.rs
@@ -173,6 +173,7 @@ impl NetworkBehaviour for Pubsub {
                                 // receiver has dropped
                                 let (topic, _) = oe.remove_entry();
                                 assert!(self.floodsub.unsubscribe(topic.clone()), "Closed sender didnt allow unsubscribing {:?}", topic);
+                                log::debug!("unsubscribed via SendError from {:?}", topic);
                                 buffer = Some(se.into_inner());
                             }
                         }

--- a/src/p2p/pubsub.rs
+++ b/src/p2p/pubsub.rs
@@ -1,0 +1,210 @@
+use futures::channel::mpsc as channel;
+use std::collections::HashMap;
+use std::sync::Arc;
+use std::task::{Context, Poll};
+
+use libp2p::floodsub::{Floodsub, Topic, FloodsubMessage, FloodsubEvent};
+use libp2p::core::{ConnectedPoint, Multiaddr, PeerId};
+use libp2p::swarm::{NetworkBehaviour, NetworkBehaviourAction, PollParameters, ProtocolsHandler};
+
+/// Currently a thin wrapper around Floodsub, perhaps supporting both Gossipsub and Floodsub later.
+/// Allows single subscription to a topic with only unbounded senders. Tracks the peers subscribed
+/// to different topics.
+pub struct Pubsub {
+    streams: HashMap<Topic, channel::UnboundedSender<Arc<PubsubMessage>>>,
+    peers: HashMap<PeerId, Vec<Topic>>,
+    floodsub: Floodsub,
+}
+
+/// Adaptation hopefully supporting somehow both Floodsub and Gossipsub Messages in the future
+#[derive(Debug, PartialEq, Eq)]
+pub struct PubsubMessage {
+    pub source: PeerId,
+    pub data: Vec<u8>,
+    // this could be an enum for gossipsub message compat, it uses u64
+    pub sequence_number: Vec<u8>,
+    // TODO: gossipsub uses topichashes, haven't checked if we could have some unifying abstraction
+    // or if we should have a hash to name mapping internally?
+    pub topics: Vec<String>,
+}
+
+impl From<FloodsubMessage> for PubsubMessage {
+    fn from(FloodsubMessage { source, data, sequence_number, topics }: FloodsubMessage) -> Self {
+        PubsubMessage {
+            source,
+            data,
+            sequence_number,
+            topics: topics.into_iter().map(String::from).collect(),
+        }
+    }
+}
+
+impl Pubsub {
+    pub fn new(peer_id: PeerId) -> Self {
+        Pubsub {
+            streams: HashMap::new(),
+            peers: HashMap::new(),
+            floodsub: Floodsub::new(peer_id),
+        }
+    }
+
+    /// Subscribes to an currently unsubscribed topic.
+    /// Returns a receiver for messages sent to the topic or `None` if subscription existed already
+    pub fn subscribe(&mut self, topic: impl Into<String>) -> Option<channel::UnboundedReceiver<Arc<PubsubMessage>>> {
+        use std::collections::hash_map::Entry;
+
+        let topic = Topic::new(topic);
+
+        match self.streams.entry(topic) {
+            Entry::Vacant(ve) => {
+                let (tx, rx) = channel::unbounded();
+
+                // TODO: unsure on what could be the limits here
+                assert!(
+                    self.floodsub.subscribe(ve.key().clone()),
+                    "subscribing to a unsubscribed topic should have succeeded");
+
+                ve.insert(tx);
+                Some(rx)
+            },
+            Entry::Occupied(_) => None,
+        }
+    }
+
+    /// Unsubscribes from a topic.
+    /// Returns true if an existing subscription was dropped
+    pub fn unsubscribe(&mut self, topic: impl Into<String>) -> bool {
+        let topic = Topic::new(topic);
+        if self.streams.remove(&topic).is_some() {
+            assert!(self.floodsub.unsubscribe(topic), "sender removed but unsubscription failed");
+            true
+        } else {
+            false
+        }
+    }
+
+    /// See [`Floodsub::publish_any`]
+    pub fn publish(&mut self, topic: impl Into<String>, data: impl Into<Vec<u8>>) {
+        self.floodsub.publish_any(Topic::new(topic), data);
+    }
+
+    /// Returns the known peers subscribed to any topic
+    pub fn known_peers(&self) -> Vec<PeerId> {
+        self.peers.keys().cloned().collect()
+    }
+
+    /// Returns the peers known to subscribe to the given topic
+    pub fn subscribed_peers(&self, topic: &Topic) -> Vec<PeerId> {
+        self.peers.iter().filter_map(|(k, v)| if v.contains(topic) { Some(k.clone()) } else { None }).collect()
+    }
+
+    /// Returns the list of currently subscribed topics. This can contain topics for which stream
+    /// has been dropped but no messages have yet been received on the topics after the drop.
+    pub fn subscribed_topics(&self) -> Vec<String> {
+        self.streams.keys().map(Topic::id).map(String::from).collect()
+    }
+
+    /// See [`Floodsub::add_node_from_partial_view`]
+    pub fn add_node_to_partial_view(&mut self, peer_id: PeerId) {
+        self.floodsub.add_node_to_partial_view(peer_id);
+    }
+
+    /// See [`Floodsub::remove_node_from_partial_view`]
+    pub fn remove_node_from_partial_view(&mut self, peer_id: &PeerId) {
+        self.floodsub.remove_node_from_partial_view(peer_id);
+    }
+}
+
+type PubsubNetworkBehaviourAction = NetworkBehaviourAction<
+    <<Pubsub as NetworkBehaviour>::ProtocolsHandler as ProtocolsHandler>::InEvent,
+    <Pubsub as NetworkBehaviour>::OutEvent>;
+
+impl NetworkBehaviour for Pubsub {
+    type ProtocolsHandler = <Floodsub as NetworkBehaviour>::ProtocolsHandler;
+    type OutEvent = void::Void;
+
+    fn new_handler(&mut self) -> Self::ProtocolsHandler {
+        self.floodsub.new_handler()
+    }
+
+    fn addresses_of_peer(&mut self, peer_id: &PeerId) -> Vec<Multiaddr> {
+        self.floodsub.addresses_of_peer(peer_id)
+    }
+
+    fn inject_connected(&mut self, peer_id: PeerId, cp: ConnectedPoint) {
+        self.floodsub.inject_connected(peer_id, cp)
+    }
+
+    fn inject_disconnected(&mut self, peer_id: &PeerId, cp: ConnectedPoint) {
+        self.floodsub.inject_disconnected(peer_id, cp)
+    }
+
+    fn inject_node_event(&mut self, peer_id: PeerId, event: <Self::ProtocolsHandler as ProtocolsHandler>::OutEvent) {
+        self.floodsub.inject_node_event(peer_id, event)
+    }
+
+    fn inject_addr_reach_failure(
+        &mut self,
+        peer_id: Option<&PeerId>,
+        addr: &Multiaddr,
+        error: &dyn std::error::Error,
+    ) {
+        self.floodsub.inject_addr_reach_failure(peer_id, addr, error)
+    }
+
+    fn poll(
+        &mut self,
+        ctx: &mut Context,
+        poll: &mut impl PollParameters,
+    ) -> Poll<PubsubNetworkBehaviourAction> {
+        use std::collections::hash_map::Entry;
+
+        match futures::ready!(self.floodsub.poll(ctx, poll)) {
+            NetworkBehaviourAction::GenerateEvent(FloodsubEvent::Message(msg)) => {
+                let topics = msg.topics.clone();
+                let msg = Arc::new(PubsubMessage::from(msg));
+                let mut buffer = None;
+
+                for topic in topics {
+                    match self.streams.entry(topic) {
+                        Entry::Occupied(oe) => {
+                            let sent = buffer.take().unwrap_or_else(|| Arc::clone(&msg));
+                            if let Some(se) = oe.get().unbounded_send(sent).err() {
+                                // receiver has dropped
+                                let (topic, _) = oe.remove_entry();
+                                assert!(self.floodsub.unsubscribe(topic.clone()), "Closed sender didnt allow unsubscribing {:?}", topic);
+                                buffer = Some(se.into_inner());
+                            }
+                        }
+                        Entry::Vacant(ve) => {
+                            panic!("we received a message to a topic we havent subscribed to {:?}, streams are probably out of sync", ve.key());
+                        }
+                    }
+                }
+                Poll::Pending
+            },
+            NetworkBehaviourAction::GenerateEvent(FloodsubEvent::Subscribed { peer_id, topic }) => {
+                let topics = self.peers.entry(peer_id).or_insert_with(Vec::new);
+                if topics.iter().find(|&t| t == &topic).is_none() {
+                    topics.push(topic);
+                }
+                Poll::Pending
+            },
+            NetworkBehaviourAction::GenerateEvent(FloodsubEvent::Unsubscribed { peer_id, topic }) => {
+                match self.peers.entry(peer_id) {
+                    Entry::Occupied(mut oe) => {
+                        let topics = oe.get_mut();
+                        topics.retain(|t| t != &topic);
+                    }
+                    _ => {},
+                }
+
+                Poll::Pending
+            },
+            NetworkBehaviourAction::DialAddress { address } => Poll::Ready(NetworkBehaviourAction::DialAddress { address }),
+            NetworkBehaviourAction::DialPeer { peer_id } => Poll::Ready(NetworkBehaviourAction::DialPeer { peer_id }),
+            NetworkBehaviourAction::SendEvent { peer_id, event } => Poll::Ready(NetworkBehaviourAction::SendEvent { peer_id, event }),
+            NetworkBehaviourAction::ReportObservedAddr { address } => Poll::Ready(NetworkBehaviourAction::ReportObservedAddr { address }),
+        }
+    }
+}

--- a/src/p2p/swarm.rs
+++ b/src/p2p/swarm.rs
@@ -6,7 +6,6 @@ use libp2p::swarm::protocols_handler::{
 };
 use libp2p::swarm::{self, NetworkBehaviour, PollParameters, Swarm};
 use std::collections::{HashMap, HashSet, VecDeque};
-use std::task::Waker;
 use std::time::Duration;
 
 #[derive(Clone, Debug)]
@@ -37,8 +36,6 @@ pub struct SwarmApi {
     connect_registry: SubscriptionRegistry<Multiaddr, Result<(), String>>,
     connections: HashMap<Multiaddr, Connection>,
     connected_peers: HashMap<PeerId, Multiaddr>,
-    /// The waker of the last polled task, if any.
-    waker: Option<Waker>,
 }
 
 impl SwarmApi {
@@ -72,18 +69,10 @@ impl SwarmApi {
 
     pub fn connect(&mut self, address: Multiaddr) -> SubscriptionFuture<Result<(), String>> {
         log::trace!("starting to connect to {}", address);
-        self.push_action(NetworkBehaviourAction::DialAddress {
+        self.events.push_back(NetworkBehaviourAction::DialAddress {
             address: address.clone(),
         });
         self.connect_registry.create_subscription(address)
-    }
-
-    fn push_action(&mut self, action: NetworkBehaviourAction) {
-        self.events.push_back(action);
-
-        if let Some(waker) = self.waker.as_ref() {
-            waker.wake_by_ref();
-        }
     }
 
     pub fn disconnect(&mut self, address: Multiaddr) -> Option<Disconnector> {
@@ -160,11 +149,9 @@ impl NetworkBehaviour for SwarmApi {
 
     fn poll(
         &mut self,
-        ctx: &mut Context,
+        _: &mut Context,
         _: &mut impl PollParameters,
     ) -> Poll<NetworkBehaviourAction> {
-        // store the poller so that we can wake the task on next push_action
-        self.waker = Some(ctx.waker().clone());
         if let Some(event) = self.events.pop_front() {
             Poll::Ready(event)
         } else {

--- a/tests/pubsub.rs
+++ b/tests/pubsub.rs
@@ -1,0 +1,131 @@
+use ipfs::Node;
+use std::time::Duration;
+use async_std::future::{timeout, pending};
+
+// Disable mdns for these tests not to connect to any local go-ipfs node
+const MDNS: bool = false;
+
+#[async_std::test]
+async fn subscribe_only_once() {
+    let a = Node::new(MDNS).await;
+    let _stream = a.pubsub_subscribe("some_topic").await.unwrap();
+    a.pubsub_subscribe("some_topic").await.unwrap_err();
+}
+
+#[async_std::test]
+async fn resubscribe_after_unsubscribe() {
+    use futures::stream::StreamExt;
+    let a = Node::new(MDNS).await;
+
+    let mut stream = a.pubsub_subscribe("topic").await.unwrap();
+    a.pubsub_unsubscribe("topic").await.unwrap();
+    // sender has been dropped
+    assert_eq!(stream.next().await, None);
+
+    drop(a.pubsub_subscribe("topic").await.unwrap());
+}
+
+#[async_std::test]
+async fn list_subscriptions() {
+    let a = Node::new(MDNS).await;
+    let _stream = a.pubsub_subscribe("topic").await.unwrap();
+    assert_eq!(a.pubsub_subscribed().await.unwrap(), &["topic"]);
+}
+
+#[async_std::test]
+async fn can_publish_without_subscribing() {
+    let a = Node::new(MDNS).await;
+    a.pubsub_publish("topic", b"foobar").await.unwrap()
+}
+
+#[async_std::test]
+async fn publish_between_two_nodes() {
+    // env_logger::init();
+    use futures::stream::StreamExt;
+    let a = Node::new(MDNS).await;
+    let b = Node::new(MDNS).await;
+
+    let (a_pk, _) = a.identity().await.unwrap();
+    let a_id = a_pk.into_peer_id();
+
+    let (b_pk, mut addrs) = b.identity().await.unwrap();
+    let b_id = b_pk.into_peer_id();
+
+    a.connect(addrs.pop().expect("b must have address to connect to")).await.unwrap();
+
+    let topic = "shared";
+
+    let mut a_msgs = a.pubsub_subscribe(topic).await.unwrap();
+    let mut b_msgs = b.pubsub_subscribe(topic).await.unwrap();
+
+    // need to wait to see both sides so that the messages will get through
+    let mut appeared = false;
+    for _ in 0..100usize {
+        if a.pubsub_peers(Some(topic)).await.unwrap().contains(&b_id) && b.pubsub_peers(Some(topic)).await.unwrap().contains(&a_id) {
+            appeared = true;
+            break;
+        }
+        timeout(
+            Duration::from_millis(100),
+            pending::<()>()).await.unwrap_err();
+    }
+
+    assert!(appeared, "timed out before both nodes appeared as pubsub peers");
+
+    a.pubsub_publish(topic, b"foobar").await.unwrap();
+    b.pubsub_publish(topic, b"barfoo").await.unwrap();
+
+    let recvd = b_msgs.next().await.unwrap();
+
+    assert_eq!(recvd.source, a_id);
+    assert_eq!(recvd.data, b"foobar");
+    assert_eq!(recvd.topics, &[topic]);
+
+    let recvd = a_msgs.next().await.unwrap();
+
+    assert_eq!(recvd.source, b_id);
+    assert_eq!(recvd.data, b"barfoo");
+    assert_eq!(recvd.topics, &[topic]);
+}
+
+#[async_std::test]
+async fn unsubscribe_via_message_reception() {
+    env_logger::init();
+    let a = Node::new(MDNS).await;
+    let b = Node::new(MDNS).await;
+
+    let (_, mut addrs) = b.identity().await.unwrap();
+
+    a.connect(addrs.pop().expect("b must have address to connect to")).await.unwrap();
+
+    // drop it right away
+    drop(a.pubsub_subscribe("shared").await.unwrap());
+    let _b_msgs = b.pubsub_subscribe("shared").await.unwrap();
+
+    assert_eq!(a.pubsub_subscribed().await.unwrap(), &["shared"]);
+    assert_eq!(b.pubsub_subscribed().await.unwrap(), &["shared"]);
+
+    // need to wait some time to allow propagation
+    timeout(
+        Duration::from_millis(100),
+        pending::<()>()).await.unwrap_err();
+
+    // once this gets to node a, the subscription should be dropped as it can no longer be sent to
+    b.pubsub_publish("shared", b"barfoo").await.unwrap();
+
+    let mut succeeded = false;
+
+    // waiting for the FloodsubEvent itself would be great but during testing this sometimes
+    // completed really fast but mostly really slow.
+    for _ in 0..100 {
+        if a.pubsub_subscribed().await.unwrap().is_empty() {
+            succeeded = true;
+            break;
+        }
+        timeout(
+            Duration::from_millis(100),
+            pending::<()>()).await.unwrap_err();
+    }
+
+    assert!(succeeded, "timed out before getting the message from b -> a");
+}

--- a/tests/pubsub.rs
+++ b/tests/pubsub.rs
@@ -1,6 +1,6 @@
+use async_std::future::{pending, timeout};
 use ipfs::Node;
 use std::time::Duration;
-use async_std::future::{timeout, pending};
 
 // Disable mdns for these tests not to connect to any local go-ipfs node
 const MDNS: bool = false;
@@ -63,7 +63,9 @@ async fn publish_between_two_nodes() {
     let (b_pk, mut addrs) = b.identity().await.unwrap();
     let b_id = b_pk.into_peer_id();
 
-    a.connect(addrs.pop().expect("b must have address to connect to")).await.unwrap();
+    a.connect(addrs.pop().expect("b must have address to connect to"))
+        .await
+        .unwrap();
 
     let topic = "shared";
 
@@ -73,16 +75,21 @@ async fn publish_between_two_nodes() {
     // need to wait to see both sides so that the messages will get through
     let mut appeared = false;
     for _ in 0..100usize {
-        if a.pubsub_peers(Some(topic)).await.unwrap().contains(&b_id) && b.pubsub_peers(Some(topic)).await.unwrap().contains(&a_id) {
+        if a.pubsub_peers(Some(topic)).await.unwrap().contains(&b_id)
+            && b.pubsub_peers(Some(topic)).await.unwrap().contains(&a_id)
+        {
             appeared = true;
             break;
         }
-        timeout(
-            Duration::from_millis(100),
-            pending::<()>()).await.unwrap_err();
+        timeout(Duration::from_millis(100), pending::<()>())
+            .await
+            .unwrap_err();
     }
 
-    assert!(appeared, "timed out before both nodes appeared as pubsub peers");
+    assert!(
+        appeared,
+        "timed out before both nodes appeared as pubsub peers"
+    );
 
     a.pubsub_publish(topic, b"foobar").await.unwrap();
     b.pubsub_publish(topic, b"barfoo").await.unwrap();


### PR DESCRIPTION
First part of #76.

Implemented by wrapping floodsub. Played around with the semantics and currently there might be too many operations; the unsubscribe might be too much. Also the method names are prefixed with `Ipfs::pubsub_` which hopefully will spark new better ideas. For naming, perhaps just removing the method name prefix would be fine.

Initially thought that maybe subscribe and unsubscribe are both needed but while testing realized it's quite strange if the unsubscription happens with on next message (or never) after drop, so I created a unsubscribe on drop wrapper for the sender. The channels used are currently all unbounded.

I initially thought that publishing messages might need to be part of the subscription, but looking at floodsubs implementation whether or not there exists a subscription is not so big of a deal, so we can always publish using that `Floodsub::publish_any`.

For testing there is a `#[doc(hidden)] ipfs::Node` which will save at least a `async_std::task::spawn`. I was thinking of adding more utilites needed in multinode tests there as well but couldn't think of more multinode test cases. The multinode test has some nasty polling loops in them, which I think are quite unavoidable, unless all events are bubbled up from the behaviour in a giant enum.