### PR TITLE
Add pubsub http

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1250,6 +1250,7 @@ dependencies = [
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "multibase 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "openssl 0.10.28 (registry+https://github.com/rust-lang/crates.io-index)",
+ "percent-encoding 2.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "prost 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "prost-build 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.104 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -265,8 +265,8 @@ dependencies = [
  "fnv 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "libipld 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "libp2p-core 0.16.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "libp2p-swarm 0.16.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libp2p-core 0.16.0 (git+https://github.com/koivunej/rust-libp2p.git?branch=v0.16.2-with-floodsub-opts)",
+ "libp2p-swarm 0.16.1 (git+https://github.com/koivunej/rust-libp2p.git?branch=v0.16.2-with-floodsub-opts)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "prost 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "prost-build 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1214,7 +1214,7 @@ dependencies = [
  "env_logger 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "libipld 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "libp2p 0.16.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libp2p 0.16.2 (git+https://github.com/koivunej/rust-libp2p.git?branch=v0.16.2-with-floodsub-opts)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "multibase 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "multihash 0.10.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1384,34 +1384,34 @@ dependencies = [
 [[package]]
 name = "libp2p"
 version = "0.16.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
+source = "git+https://github.com/koivunej/rust-libp2p.git?branch=v0.16.2-with-floodsub-opts#7314b7dccdc457c574d823cdf7a9cbaf97d6273d"
 dependencies = [
  "bytes 0.5.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "libp2p-core 0.16.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "libp2p-core-derive 0.16.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "libp2p-deflate 0.16.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "libp2p-dns 0.16.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "libp2p-floodsub 0.16.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "libp2p-gossipsub 0.16.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "libp2p-identify 0.16.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "libp2p-kad 0.16.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "libp2p-mdns 0.16.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "libp2p-mplex 0.16.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "libp2p-noise 0.16.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "libp2p-ping 0.16.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "libp2p-plaintext 0.16.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "libp2p-pnet 0.16.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "libp2p-secio 0.16.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "libp2p-swarm 0.16.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "libp2p-tcp 0.16.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "libp2p-uds 0.16.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "libp2p-wasm-ext 0.16.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "libp2p-websocket 0.16.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "libp2p-yamux 0.16.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "parity-multiaddr 0.7.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "parity-multihash 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libp2p-core 0.16.0 (git+https://github.com/koivunej/rust-libp2p.git?branch=v0.16.2-with-floodsub-opts)",
+ "libp2p-core-derive 0.16.0 (git+https://github.com/koivunej/rust-libp2p.git?branch=v0.16.2-with-floodsub-opts)",
+ "libp2p-deflate 0.16.0 (git+https://github.com/koivunej/rust-libp2p.git?branch=v0.16.2-with-floodsub-opts)",
+ "libp2p-dns 0.16.0 (git+https://github.com/koivunej/rust-libp2p.git?branch=v0.16.2-with-floodsub-opts)",
+ "libp2p-floodsub 0.16.0 (git+https://github.com/koivunej/rust-libp2p.git?branch=v0.16.2-with-floodsub-opts)",
+ "libp2p-gossipsub 0.16.0 (git+https://github.com/koivunej/rust-libp2p.git?branch=v0.16.2-with-floodsub-opts)",
+ "libp2p-identify 0.16.0 (git+https://github.com/koivunej/rust-libp2p.git?branch=v0.16.2-with-floodsub-opts)",
+ "libp2p-kad 0.16.2 (git+https://github.com/koivunej/rust-libp2p.git?branch=v0.16.2-with-floodsub-opts)",
+ "libp2p-mdns 0.16.0 (git+https://github.com/koivunej/rust-libp2p.git?branch=v0.16.2-with-floodsub-opts)",
+ "libp2p-mplex 0.16.0 (git+https://github.com/koivunej/rust-libp2p.git?branch=v0.16.2-with-floodsub-opts)",
+ "libp2p-noise 0.16.2 (git+https://github.com/koivunej/rust-libp2p.git?branch=v0.16.2-with-floodsub-opts)",
+ "libp2p-ping 0.16.0 (git+https://github.com/koivunej/rust-libp2p.git?branch=v0.16.2-with-floodsub-opts)",
+ "libp2p-plaintext 0.16.0 (git+https://github.com/koivunej/rust-libp2p.git?branch=v0.16.2-with-floodsub-opts)",
+ "libp2p-pnet 0.16.0 (git+https://github.com/koivunej/rust-libp2p.git?branch=v0.16.2-with-floodsub-opts)",
+ "libp2p-secio 0.16.1 (git+https://github.com/koivunej/rust-libp2p.git?branch=v0.16.2-with-floodsub-opts)",
+ "libp2p-swarm 0.16.1 (git+https://github.com/koivunej/rust-libp2p.git?branch=v0.16.2-with-floodsub-opts)",
+ "libp2p-tcp 0.16.0 (git+https://github.com/koivunej/rust-libp2p.git?branch=v0.16.2-with-floodsub-opts)",
+ "libp2p-uds 0.16.0 (git+https://github.com/koivunej/rust-libp2p.git?branch=v0.16.2-with-floodsub-opts)",
+ "libp2p-wasm-ext 0.16.2 (git+https://github.com/koivunej/rust-libp2p.git?branch=v0.16.2-with-floodsub-opts)",
+ "libp2p-websocket 0.16.0 (git+https://github.com/koivunej/rust-libp2p.git?branch=v0.16.2-with-floodsub-opts)",
+ "libp2p-yamux 0.16.2 (git+https://github.com/koivunej/rust-libp2p.git?branch=v0.16.2-with-floodsub-opts)",
+ "parity-multiaddr 0.7.3 (git+https://github.com/koivunej/rust-libp2p.git?branch=v0.16.2-with-floodsub-opts)",
+ "parity-multihash 0.2.3 (git+https://github.com/koivunej/rust-libp2p.git?branch=v0.16.2-with-floodsub-opts)",
  "parking_lot 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "pin-project 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "smallvec 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1421,7 +1421,7 @@ dependencies = [
 [[package]]
 name = "libp2p-core"
 version = "0.16.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
+source = "git+https://github.com/koivunej/rust-libp2p.git?branch=v0.16.2-with-floodsub-opts#7314b7dccdc457c574d823cdf7a9cbaf97d6273d"
 dependencies = [
  "asn1_der 0.6.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "bs58 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1432,9 +1432,9 @@ dependencies = [
  "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "libsecp256k1 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "multistream-select 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "parity-multiaddr 0.7.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "parity-multihash 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "multistream-select 0.7.0 (git+https://github.com/koivunej/rust-libp2p.git?branch=v0.16.2-with-floodsub-opts)",
+ "parity-multiaddr 0.7.3 (git+https://github.com/koivunej/rust-libp2p.git?branch=v0.16.2-with-floodsub-opts)",
+ "parity-multihash 0.2.3 (git+https://github.com/koivunej/rust-libp2p.git?branch=v0.16.2-with-floodsub-opts)",
  "parking_lot 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "pin-project 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "prost 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1453,7 +1453,7 @@ dependencies = [
 [[package]]
 name = "libp2p-core-derive"
 version = "0.16.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
+source = "git+https://github.com/koivunej/rust-libp2p.git?branch=v0.16.2-with-floodsub-opts#7314b7dccdc457c574d823cdf7a9cbaf97d6273d"
 dependencies = [
  "quote 1.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "syn 1.0.16 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1462,33 +1462,33 @@ dependencies = [
 [[package]]
 name = "libp2p-deflate"
 version = "0.16.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
+source = "git+https://github.com/koivunej/rust-libp2p.git?branch=v0.16.2-with-floodsub-opts#7314b7dccdc457c574d823cdf7a9cbaf97d6273d"
 dependencies = [
  "flate2 1.0.13 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "libp2p-core 0.16.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libp2p-core 0.16.0 (git+https://github.com/koivunej/rust-libp2p.git?branch=v0.16.2-with-floodsub-opts)",
 ]
 
 [[package]]
 name = "libp2p-dns"
 version = "0.16.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
+source = "git+https://github.com/koivunej/rust-libp2p.git?branch=v0.16.2-with-floodsub-opts#7314b7dccdc457c574d823cdf7a9cbaf97d6273d"
 dependencies = [
  "futures 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "libp2p-core 0.16.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libp2p-core 0.16.0 (git+https://github.com/koivunej/rust-libp2p.git?branch=v0.16.2-with-floodsub-opts)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "libp2p-floodsub"
 version = "0.16.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
+source = "git+https://github.com/koivunej/rust-libp2p.git?branch=v0.16.2-with-floodsub-opts#7314b7dccdc457c574d823cdf7a9cbaf97d6273d"
 dependencies = [
  "cuckoofilter 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "fnv 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "libp2p-core 0.16.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "libp2p-swarm 0.16.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libp2p-core 0.16.0 (git+https://github.com/koivunej/rust-libp2p.git?branch=v0.16.2-with-floodsub-opts)",
+ "libp2p-swarm 0.16.1 (git+https://github.com/koivunej/rust-libp2p.git?branch=v0.16.2-with-floodsub-opts)",
  "prost 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "prost-build 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.7.3 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1498,7 +1498,7 @@ dependencies = [
 [[package]]
 name = "libp2p-gossipsub"
 version = "0.16.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
+source = "git+https://github.com/koivunej/rust-libp2p.git?branch=v0.16.2-with-floodsub-opts#7314b7dccdc457c574d823cdf7a9cbaf97d6273d"
 dependencies = [
  "base64 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "byteorder 1.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1506,8 +1506,8 @@ dependencies = [
  "fnv 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures_codec 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "libp2p-core 0.16.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "libp2p-swarm 0.16.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libp2p-core 0.16.0 (git+https://github.com/koivunej/rust-libp2p.git?branch=v0.16.2-with-floodsub-opts)",
+ "libp2p-swarm 0.16.1 (git+https://github.com/koivunej/rust-libp2p.git?branch=v0.16.2-with-floodsub-opts)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "lru 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "prost 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1522,11 +1522,11 @@ dependencies = [
 [[package]]
 name = "libp2p-identify"
 version = "0.16.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
+source = "git+https://github.com/koivunej/rust-libp2p.git?branch=v0.16.2-with-floodsub-opts#7314b7dccdc457c574d823cdf7a9cbaf97d6273d"
 dependencies = [
  "futures 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "libp2p-core 0.16.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "libp2p-swarm 0.16.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libp2p-core 0.16.0 (git+https://github.com/koivunej/rust-libp2p.git?branch=v0.16.2-with-floodsub-opts)",
+ "libp2p-swarm 0.16.1 (git+https://github.com/koivunej/rust-libp2p.git?branch=v0.16.2-with-floodsub-opts)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "prost 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "prost-build 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1537,7 +1537,7 @@ dependencies = [
 [[package]]
 name = "libp2p-kad"
 version = "0.16.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
+source = "git+https://github.com/koivunej/rust-libp2p.git?branch=v0.16.2-with-floodsub-opts#7314b7dccdc457c574d823cdf7a9cbaf97d6273d"
 dependencies = [
  "arrayvec 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "bytes 0.5.4 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1545,10 +1545,10 @@ dependencies = [
  "fnv 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures_codec 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "libp2p-core 0.16.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "libp2p-swarm 0.16.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libp2p-core 0.16.0 (git+https://github.com/koivunej/rust-libp2p.git?branch=v0.16.2-with-floodsub-opts)",
+ "libp2p-swarm 0.16.1 (git+https://github.com/koivunej/rust-libp2p.git?branch=v0.16.2-with-floodsub-opts)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "parity-multihash 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "parity-multihash 0.2.3 (git+https://github.com/koivunej/rust-libp2p.git?branch=v0.16.2-with-floodsub-opts)",
  "prost 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "prost-build 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.7.3 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1563,7 +1563,7 @@ dependencies = [
 [[package]]
 name = "libp2p-mdns"
 version = "0.16.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
+source = "git+https://github.com/koivunej/rust-libp2p.git?branch=v0.16.2-with-floodsub-opts#7314b7dccdc457c574d823cdf7a9cbaf97d6273d"
 dependencies = [
  "async-std 1.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "data-encoding 2.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1571,8 +1571,8 @@ dependencies = [
  "either 1.5.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "libp2p-core 0.16.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "libp2p-swarm 0.16.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libp2p-core 0.16.0 (git+https://github.com/koivunej/rust-libp2p.git?branch=v0.16.2-with-floodsub-opts)",
+ "libp2p-swarm 0.16.1 (git+https://github.com/koivunej/rust-libp2p.git?branch=v0.16.2-with-floodsub-opts)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "net2 0.2.33 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.7.3 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1584,13 +1584,13 @@ dependencies = [
 [[package]]
 name = "libp2p-mplex"
 version = "0.16.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
+source = "git+https://github.com/koivunej/rust-libp2p.git?branch=v0.16.2-with-floodsub-opts#7314b7dccdc457c574d823cdf7a9cbaf97d6273d"
 dependencies = [
  "bytes 0.5.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "fnv 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures_codec 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "libp2p-core 0.16.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libp2p-core 0.16.0 (git+https://github.com/koivunej/rust-libp2p.git?branch=v0.16.2-with-floodsub-opts)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "parking_lot 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "unsigned-varint 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1599,12 +1599,12 @@ dependencies = [
 [[package]]
 name = "libp2p-noise"
 version = "0.16.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
+source = "git+https://github.com/koivunej/rust-libp2p.git?branch=v0.16.2-with-floodsub-opts#7314b7dccdc457c574d823cdf7a9cbaf97d6273d"
 dependencies = [
  "curve25519-dalek 2.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "libp2p-core 0.16.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libp2p-core 0.16.0 (git+https://github.com/koivunej/rust-libp2p.git?branch=v0.16.2-with-floodsub-opts)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "prost 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "prost-build 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1619,11 +1619,11 @@ dependencies = [
 [[package]]
 name = "libp2p-ping"
 version = "0.16.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
+source = "git+https://github.com/koivunej/rust-libp2p.git?branch=v0.16.2-with-floodsub-opts#7314b7dccdc457c574d823cdf7a9cbaf97d6273d"
 dependencies = [
  "futures 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "libp2p-core 0.16.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "libp2p-swarm 0.16.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libp2p-core 0.16.0 (git+https://github.com/koivunej/rust-libp2p.git?branch=v0.16.2-with-floodsub-opts)",
+ "libp2p-swarm 0.16.1 (git+https://github.com/koivunej/rust-libp2p.git?branch=v0.16.2-with-floodsub-opts)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.7.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "void 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1633,12 +1633,12 @@ dependencies = [
 [[package]]
 name = "libp2p-plaintext"
 version = "0.16.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
+source = "git+https://github.com/koivunej/rust-libp2p.git?branch=v0.16.2-with-floodsub-opts#7314b7dccdc457c574d823cdf7a9cbaf97d6273d"
 dependencies = [
  "bytes 0.5.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures_codec 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "libp2p-core 0.16.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libp2p-core 0.16.0 (git+https://github.com/koivunej/rust-libp2p.git?branch=v0.16.2-with-floodsub-opts)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "prost 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "prost-build 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1650,7 +1650,7 @@ dependencies = [
 [[package]]
 name = "libp2p-pnet"
 version = "0.16.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
+source = "git+https://github.com/koivunej/rust-libp2p.git?branch=v0.16.2-with-floodsub-opts#7314b7dccdc457c574d823cdf7a9cbaf97d6273d"
 dependencies = [
  "futures 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1663,7 +1663,7 @@ dependencies = [
 [[package]]
 name = "libp2p-secio"
 version = "0.16.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
+source = "git+https://github.com/koivunej/rust-libp2p.git?branch=v0.16.2-with-floodsub-opts#7314b7dccdc457c574d823cdf7a9cbaf97d6273d"
 dependencies = [
  "aes-ctr 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "ctr 0.3.2 (git+https://github.com/koivunej/stream-ciphers.git?branch=ctr128-64to128)",
@@ -1671,7 +1671,7 @@ dependencies = [
  "hmac 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "js-sys 0.3.36 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "libp2p-core 0.16.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libp2p-core 0.16.0 (git+https://github.com/koivunej/rust-libp2p.git?branch=v0.16.2-with-floodsub-opts)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "parity-send-wrapper 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "pin-project 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1692,10 +1692,10 @@ dependencies = [
 [[package]]
 name = "libp2p-swarm"
 version = "0.16.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
+source = "git+https://github.com/koivunej/rust-libp2p.git?branch=v0.16.2-with-floodsub-opts#7314b7dccdc457c574d823cdf7a9cbaf97d6273d"
 dependencies = [
  "futures 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "libp2p-core 0.16.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libp2p-core 0.16.0 (git+https://github.com/koivunej/rust-libp2p.git?branch=v0.16.2-with-floodsub-opts)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "smallvec 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "void 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1705,36 +1705,36 @@ dependencies = [
 [[package]]
 name = "libp2p-tcp"
 version = "0.16.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
+source = "git+https://github.com/koivunej/rust-libp2p.git?branch=v0.16.2-with-floodsub-opts#7314b7dccdc457c574d823cdf7a9cbaf97d6273d"
 dependencies = [
  "async-std 1.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures-timer 3.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "get_if_addrs 0.5.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "ipnet 2.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "libp2p-core 0.16.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libp2p-core 0.16.0 (git+https://github.com/koivunej/rust-libp2p.git?branch=v0.16.2-with-floodsub-opts)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "libp2p-uds"
 version = "0.16.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
+source = "git+https://github.com/koivunej/rust-libp2p.git?branch=v0.16.2-with-floodsub-opts#7314b7dccdc457c574d823cdf7a9cbaf97d6273d"
 dependencies = [
  "async-std 1.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "libp2p-core 0.16.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libp2p-core 0.16.0 (git+https://github.com/koivunej/rust-libp2p.git?branch=v0.16.2-with-floodsub-opts)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "libp2p-wasm-ext"
 version = "0.16.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
+source = "git+https://github.com/koivunej/rust-libp2p.git?branch=v0.16.2-with-floodsub-opts#7314b7dccdc457c574d823cdf7a9cbaf97d6273d"
 dependencies = [
  "futures 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "js-sys 0.3.36 (registry+https://github.com/rust-lang/crates.io-index)",
- "libp2p-core 0.16.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libp2p-core 0.16.0 (git+https://github.com/koivunej/rust-libp2p.git?branch=v0.16.2-with-floodsub-opts)",
  "parity-send-wrapper 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "wasm-bindgen 0.2.59 (registry+https://github.com/rust-lang/crates.io-index)",
  "wasm-bindgen-futures 0.4.9 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1743,13 +1743,13 @@ dependencies = [
 [[package]]
 name = "libp2p-websocket"
 version = "0.16.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
+source = "git+https://github.com/koivunej/rust-libp2p.git?branch=v0.16.2-with-floodsub-opts#7314b7dccdc457c574d823cdf7a9cbaf97d6273d"
 dependencies = [
  "async-tls 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "bytes 0.5.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "either 1.5.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "libp2p-core 0.16.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libp2p-core 0.16.0 (git+https://github.com/koivunej/rust-libp2p.git?branch=v0.16.2-with-floodsub-opts)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "quicksink 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "rustls 0.16.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1763,13 +1763,13 @@ dependencies = [
 [[package]]
 name = "libp2p-yamux"
 version = "0.16.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
+source = "git+https://github.com/koivunej/rust-libp2p.git?branch=v0.16.2-with-floodsub-opts#7314b7dccdc457c574d823cdf7a9cbaf97d6273d"
 dependencies = [
  "futures 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "libp2p-core 0.16.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libp2p-core 0.16.0 (git+https://github.com/koivunej/rust-libp2p.git?branch=v0.16.2-with-floodsub-opts)",
  "parking_lot 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "thiserror 1.0.11 (registry+https://github.com/rust-lang/crates.io-index)",
- "yamux 0.4.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "yamux 0.4.5 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -2013,7 +2013,7 @@ dependencies = [
 [[package]]
 name = "multistream-select"
 version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
+source = "git+https://github.com/koivunej/rust-libp2p.git?branch=v0.16.2-with-floodsub-opts#7314b7dccdc457c574d823cdf7a9cbaf97d6273d"
 dependencies = [
  "bytes 0.5.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.1.29 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2116,13 +2116,13 @@ dependencies = [
 [[package]]
 name = "parity-multiaddr"
 version = "0.7.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
+source = "git+https://github.com/koivunej/rust-libp2p.git?branch=v0.16.2-with-floodsub-opts#7314b7dccdc457c574d823cdf7a9cbaf97d6273d"
 dependencies = [
  "arrayref 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "bs58 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "byteorder 1.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "data-encoding 2.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "parity-multihash 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "parity-multihash 0.2.3 (git+https://github.com/koivunej/rust-libp2p.git?branch=v0.16.2-with-floodsub-opts)",
  "percent-encoding 2.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.104 (registry+https://github.com/rust-lang/crates.io-index)",
  "static_assertions 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2133,7 +2133,7 @@ dependencies = [
 [[package]]
 name = "parity-multihash"
 version = "0.2.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
+source = "git+https://github.com/koivunej/rust-libp2p.git?branch=v0.16.2-with-floodsub-opts#7314b7dccdc457c574d823cdf7a9cbaf97d6273d"
 dependencies = [
  "blake2 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "bytes 0.5.4 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -3686,16 +3686,15 @@ dependencies = [
 
 [[package]]
 name = "yamux"
-version = "0.4.4"
+version = "0.4.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "bytes 0.5.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "nohash-hasher 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "parking_lot 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.7.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "thiserror 1.0.11 (registry+https://github.com/rust-lang/crates.io-index)",
+ "static_assertions 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -3868,28 +3867,28 @@ dependencies = [
 "checksum libipld-base 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "e8c4f844ea2e357f53cb53a2dd28a1dd4ab9d61d75d121cb8468b1a12b621970"
 "checksum libipld-macro 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "6fbc55b3b493e909833fb7af7f5deed4e994e2c625c648777711f8791a02ebb5"
 "checksum libloading 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)" = "f2b111a074963af1d37a139918ac6d49ad1d0d5e47f72fd55388619691a7d753"
-"checksum libp2p 0.16.2 (registry+https://github.com/rust-lang/crates.io-index)" = "bba17ee9cac4bb89de5812159877d9b4f0a993bf41697a5a875940cd1eb71f24"
-"checksum libp2p-core 0.16.0 (registry+https://github.com/rust-lang/crates.io-index)" = "3b874594c4b29de1a29f27871feba8e6cd13aa54a8a1e8f8c7cf3dfac5ca287c"
-"checksum libp2p-core-derive 0.16.0 (registry+https://github.com/rust-lang/crates.io-index)" = "96d472e9d522f588805c77801de10b957be84e10f019ca5f869fa1825b15ea9b"
-"checksum libp2p-deflate 0.16.0 (registry+https://github.com/rust-lang/crates.io-index)" = "2e25004d4d9837b44b22c5f1a69be1724a5168fef6cff1716b5176a972c3aa62"
-"checksum libp2p-dns 0.16.0 (registry+https://github.com/rust-lang/crates.io-index)" = "b99e552f9939b606eb4b59f7f64d9b01e3f96752f47e350fc3c5fc646ed3f649"
-"checksum libp2p-floodsub 0.16.0 (registry+https://github.com/rust-lang/crates.io-index)" = "1d3234f12e44f9a50351a9807b97fe7de11eb9ae4482370392ba10da6dc90722"
-"checksum libp2p-gossipsub 0.16.0 (registry+https://github.com/rust-lang/crates.io-index)" = "d46cb3e0841bd951cbf4feae56cdc081e6347836a644fb260c3ec554149b4006"
-"checksum libp2p-identify 0.16.0 (registry+https://github.com/rust-lang/crates.io-index)" = "bfeb935a9bd41263e4f3a24b988e9f4a044f3ae89ac284e83c17fe2f84e0d66b"
-"checksum libp2p-kad 0.16.2 (registry+https://github.com/rust-lang/crates.io-index)" = "464dc8412978d40f0286be72ed9ab5e0e1386a4a06e7f174526739b5c3c1f041"
-"checksum libp2p-mdns 0.16.0 (registry+https://github.com/rust-lang/crates.io-index)" = "881fcfb360c2822db9f0e6bb6f89529621556ed9a8b038313414eda5107334de"
-"checksum libp2p-mplex 0.16.0 (registry+https://github.com/rust-lang/crates.io-index)" = "d8507b37ad0eed275efcde67a023c3d85af6c80768b193845b9288e848e1af95"
-"checksum libp2p-noise 0.16.2 (registry+https://github.com/rust-lang/crates.io-index)" = "b15a8a3d71f898beb6f854c8aae27aa1d198e0d1f2e49412261c2d90ef39675a"
-"checksum libp2p-ping 0.16.0 (registry+https://github.com/rust-lang/crates.io-index)" = "33d22f2f228b3a828dca1cb8aa9fa331e0bc9c36510cb2c1916956e20dc85e8c"
-"checksum libp2p-plaintext 0.16.0 (registry+https://github.com/rust-lang/crates.io-index)" = "56126a204d7b3382bac163143ff4125a14570b3ba76ba979103d1ae1abed1923"
-"checksum libp2p-pnet 0.16.0 (registry+https://github.com/rust-lang/crates.io-index)" = "b916938a8868f75180aeeffcc6a516a922d165e8fa2a90b57bad989d1ccbb57a"
-"checksum libp2p-secio 0.16.1 (registry+https://github.com/rust-lang/crates.io-index)" = "1219e9ecb4945d7331a05f5ffe96a1f6e28051bfa1223d4c60353c251de0354e"
-"checksum libp2p-swarm 0.16.1 (registry+https://github.com/rust-lang/crates.io-index)" = "275471e7c0e88ae004660866cd54f603bd8bd1f4caef541a27f50dd8640c4d4c"
-"checksum libp2p-tcp 0.16.0 (registry+https://github.com/rust-lang/crates.io-index)" = "f9e80ad4e3535345f3d666554ce347d3100453775611c05c60786bf9a1747a10"
-"checksum libp2p-uds 0.16.0 (registry+https://github.com/rust-lang/crates.io-index)" = "76d329564a43da9d0e055a5b938633c4a8ceab1f59cec133fbc4647917c07341"
-"checksum libp2p-wasm-ext 0.16.2 (registry+https://github.com/rust-lang/crates.io-index)" = "923581c055bc4b8c5f42d4ce5ef43e52fe5216f1ea4bc26476cb8a966ce6220b"
-"checksum libp2p-websocket 0.16.0 (registry+https://github.com/rust-lang/crates.io-index)" = "5351ca9eea122081c1c0f9323164d2918cac29b5a6bfe5054d4ba8ec9447cf42"
-"checksum libp2p-yamux 0.16.2 (registry+https://github.com/rust-lang/crates.io-index)" = "9dac30de24ccde0e67f363d71a125c587bbe6589503f664947e9b084b68a34f1"
+"checksum libp2p 0.16.2 (git+https://github.com/koivunej/rust-libp2p.git?branch=v0.16.2-with-floodsub-opts)" = "<none>"
+"checksum libp2p-core 0.16.0 (git+https://github.com/koivunej/rust-libp2p.git?branch=v0.16.2-with-floodsub-opts)" = "<none>"
+"checksum libp2p-core-derive 0.16.0 (git+https://github.com/koivunej/rust-libp2p.git?branch=v0.16.2-with-floodsub-opts)" = "<none>"
+"checksum libp2p-deflate 0.16.0 (git+https://github.com/koivunej/rust-libp2p.git?branch=v0.16.2-with-floodsub-opts)" = "<none>"
+"checksum libp2p-dns 0.16.0 (git+https://github.com/koivunej/rust-libp2p.git?branch=v0.16.2-with-floodsub-opts)" = "<none>"
+"checksum libp2p-floodsub 0.16.0 (git+https://github.com/koivunej/rust-libp2p.git?branch=v0.16.2-with-floodsub-opts)" = "<none>"
+"checksum libp2p-gossipsub 0.16.0 (git+https://github.com/koivunej/rust-libp2p.git?branch=v0.16.2-with-floodsub-opts)" = "<none>"
+"checksum libp2p-identify 0.16.0 (git+https://github.com/koivunej/rust-libp2p.git?branch=v0.16.2-with-floodsub-opts)" = "<none>"
+"checksum libp2p-kad 0.16.2 (git+https://github.com/koivunej/rust-libp2p.git?branch=v0.16.2-with-floodsub-opts)" = "<none>"
+"checksum libp2p-mdns 0.16.0 (git+https://github.com/koivunej/rust-libp2p.git?branch=v0.16.2-with-floodsub-opts)" = "<none>"
+"checksum libp2p-mplex 0.16.0 (git+https://github.com/koivunej/rust-libp2p.git?branch=v0.16.2-with-floodsub-opts)" = "<none>"
+"checksum libp2p-noise 0.16.2 (git+https://github.com/koivunej/rust-libp2p.git?branch=v0.16.2-with-floodsub-opts)" = "<none>"
+"checksum libp2p-ping 0.16.0 (git+https://github.com/koivunej/rust-libp2p.git?branch=v0.16.2-with-floodsub-opts)" = "<none>"
+"checksum libp2p-plaintext 0.16.0 (git+https://github.com/koivunej/rust-libp2p.git?branch=v0.16.2-with-floodsub-opts)" = "<none>"
+"checksum libp2p-pnet 0.16.0 (git+https://github.com/koivunej/rust-libp2p.git?branch=v0.16.2-with-floodsub-opts)" = "<none>"
+"checksum libp2p-secio 0.16.1 (git+https://github.com/koivunej/rust-libp2p.git?branch=v0.16.2-with-floodsub-opts)" = "<none>"
+"checksum libp2p-swarm 0.16.1 (git+https://github.com/koivunej/rust-libp2p.git?branch=v0.16.2-with-floodsub-opts)" = "<none>"
+"checksum libp2p-tcp 0.16.0 (git+https://github.com/koivunej/rust-libp2p.git?branch=v0.16.2-with-floodsub-opts)" = "<none>"
+"checksum libp2p-uds 0.16.0 (git+https://github.com/koivunej/rust-libp2p.git?branch=v0.16.2-with-floodsub-opts)" = "<none>"
+"checksum libp2p-wasm-ext 0.16.2 (git+https://github.com/koivunej/rust-libp2p.git?branch=v0.16.2-with-floodsub-opts)" = "<none>"
+"checksum libp2p-websocket 0.16.0 (git+https://github.com/koivunej/rust-libp2p.git?branch=v0.16.2-with-floodsub-opts)" = "<none>"
+"checksum libp2p-yamux 0.16.2 (git+https://github.com/koivunej/rust-libp2p.git?branch=v0.16.2-with-floodsub-opts)" = "<none>"
 "checksum librocksdb-sys 6.6.4 (registry+https://github.com/rust-lang/crates.io-index)" = "4e3b727e2dd20ec2fb7ed93f23d9fd5328a0871185485ebdaff007b47d3e27e4"
 "checksum libsecp256k1 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)" = "1fc1e2c808481a63dc6da2074752fdd4336a3c8fcc68b83db6f1fd5224ae7962"
 "checksum libz-sys 1.0.25 (registry+https://github.com/rust-lang/crates.io-index)" = "2eb5e43362e38e2bca2fd5f5134c4d4564a23a5c28e9b95411652021a8675ebe"
@@ -3915,7 +3914,7 @@ dependencies = [
 "checksum multihash 0.10.1 (registry+https://github.com/rust-lang/crates.io-index)" = "47fbc227f7e2b1cb701f95404579ecb2668abbdd3c7ef7a6cbb3cc0d3b236869"
 "checksum multimap 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)" = "a97fbd5d00e0e37bfb10f433af8f5aaf631e739368dc9fc28286ca81ca4948dc"
 "checksum multipart 0.16.1 (registry+https://github.com/rust-lang/crates.io-index)" = "136eed74cadb9edd2651ffba732b19a450316b680e4f48d6c79e905799e19d01"
-"checksum multistream-select 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "f938ffe420493e77c8b6cbcc3f282283f68fc889c5dcbc8e51668d5f3a01ad94"
+"checksum multistream-select 0.7.0 (git+https://github.com/koivunej/rust-libp2p.git?branch=v0.16.2-with-floodsub-opts)" = "<none>"
 "checksum net2 0.2.33 (registry+https://github.com/rust-lang/crates.io-index)" = "42550d9fb7b6684a6d404d9fa7250c2eb2646df731d1c06afc06dcee9e1bcf88"
 "checksum nodrop 0.1.14 (registry+https://github.com/rust-lang/crates.io-index)" = "72ef4a56884ca558e5ddb05a1d1e7e1bfd9a68d9ed024c21704cc98872dae1bb"
 "checksum nohash-hasher 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "2bf50223579dc7cdcfb3bfcacf7069ff68243f8c363f62ffa99cf000a6b9c451"
@@ -3927,8 +3926,8 @@ dependencies = [
 "checksum opaque-debug 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)" = "2839e79665f131bdb5782e51f2c6c9599c133c6098982a54c794358bf432529c"
 "checksum openssl 0.10.28 (registry+https://github.com/rust-lang/crates.io-index)" = "973293749822d7dd6370d6da1e523b0d1db19f06c459134c658b2a4261378b52"
 "checksum openssl-sys 0.9.54 (registry+https://github.com/rust-lang/crates.io-index)" = "1024c0a59774200a555087a6da3f253a9095a5f344e353b212ac4c8b8e450986"
-"checksum parity-multiaddr 0.7.3 (registry+https://github.com/rust-lang/crates.io-index)" = "f77055f9e81921a8cc7bebeb6cded3d128931d51f1e3dd6251f0770a6d431477"
-"checksum parity-multihash 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)" = "7a1cd2ba02391b81367bec529fb209019d718684fdc8ad6a712c2b536e46f775"
+"checksum parity-multiaddr 0.7.3 (git+https://github.com/koivunej/rust-libp2p.git?branch=v0.16.2-with-floodsub-opts)" = "<none>"
+"checksum parity-multihash 0.2.3 (git+https://github.com/koivunej/rust-libp2p.git?branch=v0.16.2-with-floodsub-opts)" = "<none>"
 "checksum parity-send-wrapper 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "aa9777aa91b8ad9dd5aaa04a9b6bcb02c7f1deb952fca5a66034d5e63afc5c6f"
 "checksum parking_lot 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)" = "92e98c49ab0b7ce5b222f2cc9193fc4efe11c6d0bd4f648e374684a6857b1cfc"
 "checksum parking_lot 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)" = "f842b1982eb6c2fe34036a4fbfb06dd185a3f5c8edfaacdf7d1ea10b07de6252"
@@ -4103,6 +4102,6 @@ dependencies = [
 "checksum winapi-x86_64-pc-windows-gnu 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 "checksum ws2_32-sys 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "d59cefebd0c892fa2dd6de581e937301d8552cb44489cdff035c6187cb63fa5e"
 "checksum x25519-dalek 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)" = "637ff90c9540fa3073bb577e65033069e4bae7c79d49d74aa3ffdf5342a53217"
-"checksum yamux 0.4.4 (registry+https://github.com/rust-lang/crates.io-index)" = "f03098897b734bd943ab23f6aa9f98aafd72a88516deedd66f9d564c57bf2f19"
+"checksum yamux 0.4.5 (registry+https://github.com/rust-lang/crates.io-index)" = "84300bb493cc878f3638b981c62b4632ec1a5c52daaa3036651e8c106d3b55ea"
 "checksum zeroize 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "3cbac2ed2ba24cc90f5e06485ac8c7c1e5449fe8911aef4d8877218af021a5b8"
 "checksum zeroize_derive 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "de251eec69fc7c1bc3923403d18ececb929380e016afe103da75f396704f8ca2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,3 +43,9 @@ members = [ "bitswap", "http", "examples" ]
 
 [patch.crates-io]
 ctr = { git = "https://github.com/koivunej/stream-ciphers.git", branch = "ctr128-64to128" }
+
+# these are needed for the floodsub local originated messages to be seen by subscribers
+libp2p = { git = "https://github.com/koivunej/rust-libp2p.git", branch = "v0.16.2-with-floodsub-opts" }
+libp2p-core = { git = "https://github.com/koivunej/rust-libp2p.git", branch = "v0.16.2-with-floodsub-opts" }
+libp2p-swarm = { git = "https://github.com/koivunej/rust-libp2p.git", branch = "v0.16.2-with-floodsub-opts" }
+libp2p-floodsub = { git = "https://github.com/koivunej/rust-libp2p.git", branch = "v0.16.2-with-floodsub-opts" }

--- a/http/Cargo.toml
+++ b/http/Cargo.toml
@@ -21,6 +21,7 @@ warp = { version = "0.2" }
 thiserror = "1.0"
 multibase = "0.8.0"
 futures = "0.3"
+percent-encoding = "*"
 
 # openssl is required for rsa keygen but not used by the rust-ipfs or it's dependencies
 openssl = "0.10"

--- a/http/src/v0.rs
+++ b/http/src/v0.rs
@@ -4,6 +4,7 @@ use std::convert::Infallible;
 pub mod id;
 pub mod swarm;
 pub mod version;
+pub mod pubsub;
 
 pub mod support;
 pub use support::recover_as_message_response;
@@ -43,7 +44,7 @@ where
             .or(warp::path!("object" / ..).and_then(not_implemented))
             .or(warp::path!("pin" / ..).and_then(not_implemented))
             .or(warp::path!("ping" / ..).and_then(not_implemented))
-            .or(warp::path!("pubsub" / ..).and_then(not_implemented))
+            .or(pubsub::routes(ipfs))
             .or(warp::path!("refs" / ..).and_then(not_implemented))
             .or(warp::path!("repo" / ..).and_then(not_implemented))
             .or(warp::path!("stats" / ..).and_then(not_implemented))

--- a/http/src/v0.rs
+++ b/http/src/v0.rs
@@ -2,9 +2,9 @@ use ipfs::{Ipfs, IpfsTypes};
 use std::convert::Infallible;
 
 pub mod id;
+pub mod pubsub;
 pub mod swarm;
 pub mod version;
-pub mod pubsub;
 
 pub mod support;
 pub use support::recover_as_message_response;

--- a/http/src/v0/pubsub.rs
+++ b/http/src/v0/pubsub.rs
@@ -1,0 +1,415 @@
+use warp::Filter;
+use warp::hyper::body::Bytes;
+use serde::{Serialize, Deserialize};
+use futures::stream::{Stream, TryStream};
+use tokio::sync::Mutex;
+use tokio::sync::broadcast;
+use tokio::sync::mpsc;
+
+use std::fmt;
+use std::collections::HashMap;
+use std::sync::Arc;
+use ipfs::{Ipfs, IpfsTypes, Error, PeerId};
+use super::support::{with_ipfs, StringError};
+
+#[derive(Default)]
+pub struct Pubsub {
+    subscriptions: Mutex<HashMap<String, broadcast::Sender<Result<PreformattedJsonMessage, StreamError>>>>,
+    //shoveler_tx: mpsc::Sender<(Subscription, broadcast::Sender<PubsubMessage)>>,
+}
+
+pub fn routes<T: IpfsTypes>(ipfs: &Ipfs<T>) -> impl warp::Filter<Extract = impl warp::Reply, Error = warp::Rejection> + Clone {
+    peers(ipfs)
+        .or(list_subscriptions(ipfs))
+        .or(publish(ipfs))
+        .or(subscribe(ipfs, Default::default()))
+}
+
+pub fn peers<T: IpfsTypes>(ipfs: &Ipfs<T>) -> impl warp::Filter<Extract = impl warp::Reply, Error = warp::Rejection> + Clone {
+    warp::path!("peers")
+        .and(warp::get().or(warp::post()))
+        .unify()
+        .and(with_ipfs(ipfs))
+        .and(warp::query::<OptionalTopicParameter>().map(|tp: OptionalTopicParameter| tp.topic))
+        .and_then(inner_peers)
+}
+
+async fn inner_peers<T: IpfsTypes>(ipfs: Ipfs<T>, topic: Option<String>) -> Result<impl warp::Reply, warp::Rejection>{
+    let peers = ipfs.pubsub_peers(topic.as_ref().map(String::as_str)).await
+        .map_err(|e| warp::reject::custom(StringError::from(e)))?;
+
+    Ok(warp::reply::json(&StringListResponse { strings: peers.into_iter().map(|id| id.to_string()).collect() }))
+}
+
+pub fn list_subscriptions<T: IpfsTypes>(ipfs: &Ipfs<T>) -> impl warp::Filter<Extract = impl warp::Reply, Error = warp::Rejection> + Clone {
+    warp::path!("ls")
+        .and(warp::get().or(warp::post()))
+        .unify()
+        .and(with_ipfs(ipfs))
+        .and_then(inner_ls)
+}
+
+async fn inner_ls<T: IpfsTypes>(ipfs: Ipfs<T>) -> Result<impl warp::Reply, warp::Rejection> {
+    let topics = ipfs.pubsub_subscribed()
+        .await
+        .map_err(|e| warp::reject::custom(StringError::from(e)))?;
+
+    Ok(warp::reply::json(&StringListResponse { strings: topics }))
+}
+
+pub fn publish<T: IpfsTypes>(ipfs: &Ipfs<T>) -> impl warp::Filter<Extract = impl warp::Reply, Error = warp::Rejection> + Clone {
+    warp::path!("pub")
+        .and(warp::post())
+        .and(with_ipfs(ipfs))
+        .and(publish_args(b"arg"))
+        .and_then(inner_publish)
+}
+
+async fn inner_publish<T: IpfsTypes>(ipfs: Ipfs<T>, PublishArgs { topic, message }: PublishArgs) -> Result<impl warp::Reply, warp::Rejection> {
+    ipfs.pubsub_publish(&topic, &message.into_inner())
+        .await
+        .map_err(|e| warp::reject::custom(StringError::from(e)))?;
+    Ok(warp::reply::reply())
+}
+
+
+pub fn subscribe<T: IpfsTypes>(ipfs: &Ipfs<T>, pubsub: Arc<Pubsub>) -> impl warp::Filter<Extract = impl warp::Reply, Error = warp::Rejection> + Clone {
+    warp::path!("sub")
+        .and(warp::get().or(warp::post()))
+        .unify()
+        .and(with_ipfs(ipfs))
+        .and(warp::any().map(move || pubsub.clone()))
+        .and(warp::query::<TopicParameter>())
+        .and_then(|ipfs, pubsub, TopicParameter { topic }| async move {
+            Ok::<_, warp::Rejection>(StreamResponse(inner_subscribe(ipfs, pubsub, topic).await))
+        })
+}
+
+async fn inner_subscribe<T: IpfsTypes>(ipfs: Ipfs<T>, pubsub: Arc<Pubsub>, topic: String) -> impl TryStream<Ok = PreformattedJsonMessage, Error = StreamError> {
+    use std::collections::hash_map::Entry;
+    use futures::stream::{StreamExt, TryStreamExt};
+    // accessing this through mutex bets on "most accesses would need write access" as in most
+    // requests would be asking for new subscriptions, which would require RwLock upgrading
+    // from write, which is not supported operation either.
+    let mut guard = pubsub.subscriptions.lock().await;
+
+    let rx = match guard.entry(topic) {
+        Entry::Occupied(oe) => {
+            // the easiest case: just join in, even if there are no other subscribers at the
+            // moment
+            oe.get().subscribe()
+        }
+        Entry::Vacant(ve) => {
+
+            let topic = ve.key().clone();
+
+            // the returned stream needs to be set up to be shoveled in a background task
+            let mut shoveled = ipfs.pubsub_subscribe(&topic).await
+                .expect("new subscriptions shouldn't fail while holding the lock");
+
+            // using broadcast channel should allow us have N concurrent subscribes and
+            // preformatted json should give us good enough performance
+            let (tx, rx) = broadcast::channel::<Result<PreformattedJsonMessage, StreamError>>(4);
+
+            // this will be used to create more subscriptions
+            ve.insert(tx.clone());
+
+            let pubsub = Arc::clone(&pubsub);
+
+            // FIXME: handling this all efficiently in single task would require getting a
+            // stream of "all streams" from ipfs::p2p::Behaviour ... perhaps one could be added
+            // alongside the current "spread per topic" somehow?
+            tokio::spawn(async move {
+                loop {
+                    loop {
+                        let next = match shoveled.next().await {
+                            Some(next) => preformat(next),
+                            // stop shoveling
+                            None => break,
+                        };
+
+                        if tx.send(next).is_err() {
+                            // currently no more subscribers
+                            break;
+                        }
+                    }
+
+                    let mut guard = pubsub.subscriptions.lock().await;
+
+                    // as this can take a long time to acquire the mutex, we might get a new
+                    // subscriber in the between
+
+                    if let Entry::Occupied(oe) = guard.entry(topic.clone()) {
+                        if oe.get().receiver_count() > 0 {
+                            log::trace!("got a new subscriber between removing");
+                            // a new subscriber has appeared since our previous send failure.
+                            // it is possible it gets dropped while we hold the lock, but then
+                            // we will eventually exit the next await ... FIXME: perhaps there
+                            // should be a timeout?
+                            continue;
+                        }
+                        // really no more subscribers, unsubscribe and terminate the shoveling
+                        // task for this stream. racing this will have to happen through mutex.
+                        oe.remove();
+                        return;
+                    } else {
+                        unreachable!("only way to remove subscriptions from
+                            ipfs-http::v0::pubsub::Pubsub is through tasks exiting");
+                    }
+                }
+            });
+
+            rx
+        }
+    };
+
+    rx.into_stream().map(|res| res.map_err(|_| StreamError::Recv).and_then(|res| res))
+}
+
+#[derive(Debug, Clone)]
+enum StreamError {
+    Serialization,
+    Recv
+}
+
+impl fmt::Display for StreamError {
+    fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
+        match self {
+            StreamError::Serialization => write!(fmt, "failed to serialize received message"),
+            StreamError::Recv => write!(fmt, "consuming the stream too slowly")
+        }
+    }
+}
+
+impl std::error::Error for StreamError {}
+
+#[derive(Debug, Serialize)]
+struct PubsubHttpApiMessage {
+    from: String,
+    data: String,
+    seqno: String,
+    #[serde(rename = "topicIDs")]
+    topics: Vec<String>,
+}
+
+impl<T> From<T> for PubsubHttpApiMessage
+    where T: AsRef<ipfs::PubsubMessage>
+{
+    fn from(msg: T) -> Self {
+        use multibase::Base::Base64Pad;
+        let msg = msg.as_ref();
+
+        let from = Base64Pad.encode(msg.source.as_bytes());
+        let data = Base64Pad.encode(&msg.data);
+        let seqno = Base64Pad.encode(&msg.sequence_number);
+        let topics = msg.topics.clone();
+
+        PubsubHttpApiMessage {
+            from,
+            data,
+            seqno,
+            topics
+        }
+    }
+}
+
+/// Bytes backed preformatted json + newline for subscription response stream.
+#[derive(Clone)]
+struct PreformattedJsonMessage(Bytes);
+
+impl From<Bytes> for PreformattedJsonMessage {
+    fn from(b: Bytes) -> Self {
+        Self(b)
+    }
+}
+
+impl Into<Bytes> for PreformattedJsonMessage {
+    fn into(self) -> Bytes {
+        self.0
+    }
+}
+
+/// Formats the given pubsub message into json and a newline, as is the subscription format.
+fn preformat(msg: impl AsRef<ipfs::PubsubMessage>) -> Result<PreformattedJsonMessage, StreamError> {
+    serde_json::to_vec(&PubsubHttpApiMessage::from(msg))
+        .map(|mut vec| { vec.push(b'\n'); vec })
+        .map(Bytes::from)
+        .map(PreformattedJsonMessage::from)
+        .map_err(|e| {
+            log::error!("failed to serialize PubsubMessage: {}", e);
+            StreamError::Serialization
+        })
+}
+
+struct StreamResponse<S>(S);
+
+impl<S> warp::Reply for StreamResponse<S>
+    where S: futures::stream::TryStream + Send + Sync + 'static,
+          S::Ok: Into<Bytes>,
+          S::Error: std::error::Error + Send + Sync + 'static
+{
+    fn into_response(self) -> warp::reply::Response {
+        use warp::hyper::Body;
+        use futures::stream::TryStreamExt;
+        use warp::http::header::{HeaderValue, TRAILER, CONTENT_TYPE};
+
+        // while it may seem like the S::Error is handled somehow it currently just means the
+        // response will stop. hopefully later it can be used to become trailer headers.
+        let mut resp = warp::reply::Response::new(Body::wrap_stream(self.0.into_stream()));
+        let mut headers = resp.headers_mut();
+
+        // FIXME: unable to send this header with warp/hyper right now
+        headers.insert(TRAILER, HeaderValue::from_static("X-Stream-Error"));
+        headers.insert(CONTENT_TYPE, HeaderValue::from_static("application/json"));
+        headers.insert("X-Chunked-Output", HeaderValue::from_static("1"));
+
+        resp
+    }
+}
+
+#[derive(Debug, Deserialize)]
+struct TopicParameter {
+    #[serde(rename = "arg")]
+    topic: String,
+}
+
+#[derive(Debug, Deserialize)]
+struct OptionalTopicParameter {
+    #[serde(rename = "arg")]
+    topic: Option<String>,
+}
+
+// GET|POST /pubsub/peers or /pubsub/peers/?arg=topic
+//fn peers(topic: Option<String>) {}
+
+// GET|POST /pubsub/pub
+//  - two args in query: topic and query: ?arg=topic&arg=msg
+//    - not sure if msgs can be newline delimited
+//  - topic in query, newline delimited msgs in body: ?arg=topic
+//    - still unsure on the content splitting, how does it work with "any bytes"
+//fn publish(topic: String, msg: Vec<u8>) {}
+
+// GET|POST /pubsub/sub?arg=topic
+//  - persistent subscription
+//  - needs header Trailer: X-Stream-Error
+//    - we cannot end stream with error with hyper and warp at the moment
+//fn subscribe(topic: String) {}
+
+// GET|[POST??] /pubsub/ls lists the ongoing local subscriptions
+//fn ls() {}
+
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "PascalCase")]
+struct StringListResponse {
+    strings: Vec<String>
+}
+
+#[derive(Debug)]
+struct PublishArgs {
+    topic: String,
+    message: QueryOrBody,
+}
+
+#[derive(Debug)]
+enum QueryOrBody {
+    Query(Vec<u8>),
+    #[allow(dead_code)]
+    Body(Vec<u8>),
+}
+
+impl QueryOrBody {
+    fn into_inner(self) -> Vec<u8> {
+        match self {
+            Self::Query(x) | Self::Body(x) => x,
+        }
+    }
+}
+
+/// `parameter_name` is bytes slice because there is no percent decoding done for that component.
+fn publish_args(parameter_name: &'static [u8]) -> impl warp::Filter<Extract = (PublishArgs, ), Error = warp::Rejection> + Copy {
+    warp::filters::query::raw()
+        .and_then(move |s: String| {
+            let ret = if s.is_empty() {
+                Err(warp::reject::custom(RequiredArgumentMissing(b"topic")))
+            } else {
+                // sadly we can't use url::form_urlencoded::parse here as it will do lossy
+                // conversion to utf8 without us being able to recover the raw bytes, which are
+                // used by js-ipfs/ipfs-http-client to encode raw Buffers:
+                // https://github.com/ipfs/js-ipfs/blob/master/packages/ipfs-http-client/src/pubsub/publish.js
+                let mut args = QueryAsRawPartsParser { input: s.as_bytes() }
+                    .filter(|&(k, _)| k == parameter_name)
+                    .map(|t| t.1);
+
+                let first = args.next()
+                    // can't be missing
+                    .ok_or_else(|| warp::reject::custom(RequiredArgumentMissing(b"arg")))
+                    // decode into Result<String, warp::Rejection>
+                    .and_then(|raw_first| percent_encoding::percent_decode(raw_first)
+                        .decode_utf8()
+                        .map(|cow| cow.into_owned())
+                        .map_err(|_| warp::reject::custom(NonUtf8Topic))
+                    );
+
+                first.map(move |first| {
+                    // continue to second arg, which may or may not be present
+                    let second = args.next()
+                        .map(|slice| percent_encoding::percent_decode(slice).collect::<Vec<_>>())
+                        .map(QueryOrBody::Query);
+
+                    (first, second)
+                })
+            };
+
+            futures::future::ready(ret)
+        })
+        .and_then(|(topic, opt_arg) : (String, Option<QueryOrBody>)| {
+            let ret = if let Some(message) = opt_arg {
+                Ok(PublishArgs { topic, message })
+            } else {
+                // this branch should check for multipart body, however the js-http client is not
+                // using that so we can leave it probably for now. Looks like warp doesn't support
+                // multipart bodies without Content-Length so `go-ipfs` is not supported at this
+                // time.
+                Err(warp::reject::custom(RequiredArgumentMissing(b"data")))
+            };
+            futures::future::ready(ret)
+        })
+}
+
+#[derive(Debug)]
+struct NonUtf8Topic;
+impl warp::reject::Reject for NonUtf8Topic {}
+
+#[derive(Debug)]
+struct RequiredArgumentMissing(&'static [u8]);
+impl warp::reject::Reject for RequiredArgumentMissing {}
+
+struct QueryAsRawPartsParser<'a> { input: &'a [u8] }
+
+// This has been monkey'd from https://github.com/servo/rust-url/blob/cce2d32015419b38f00c210430ecd3059105a7f2/src/form_urlencoded.rs
+impl<'a> Iterator for QueryAsRawPartsParser<'a> {
+    type Item = (&'a [u8], &'a [u8]);
+
+    fn next(&mut self) -> Option<Self::Item> {
+        loop {
+            if self.input.is_empty() {
+                return None
+            }
+
+            let mut split2 = self.input.splitn(2, |&b| b == b'&');
+
+            let sequence = split2.next().expect("splitn will always return first");
+            self.input = split2.next().unwrap_or(&[][..]);
+
+            if sequence.is_empty() {
+                continue;
+            }
+
+            let mut split2 = sequence.splitn(2, |&b| b == b'=');
+            let name = split2.next().unwrap();
+            let value = split2.next().unwrap_or(&[][..]);
+            // original implementation calls percent_decode for both arguments into Cow<str>
+            return Some((name, value));
+        }
+    }
+}

--- a/http/src/v0/pubsub.rs
+++ b/http/src/v0/pubsub.rs
@@ -183,8 +183,13 @@ async fn inner_subscribe<T: IpfsTypes>(
     };
 
     // map recv errors into the StreamError and flatten
+    let mut errored = false;
     rx.into_stream()
         .map(|res| res.map_err(|_| StreamError::Recv).and_then(|res| res))
+        .take_while(move |res| {
+            // return until the first error
+            !std::mem::replace(&mut errored, res.is_err())
+        })
 }
 
 /// Shovel task takes items from the [`SubscriptionStream`], formats them and passes them on to

--- a/http/src/v0/pubsub.rs
+++ b/http/src/v0/pubsub.rs
@@ -1,21 +1,19 @@
 use warp::Filter;
 use warp::hyper::body::Bytes;
 use serde::{Serialize, Deserialize};
-use futures::stream::{Stream, TryStream};
+use futures::stream::TryStream;
 use tokio::sync::Mutex;
 use tokio::sync::broadcast;
-use tokio::sync::mpsc;
 
 use std::fmt;
 use std::collections::HashMap;
 use std::sync::Arc;
-use ipfs::{Ipfs, IpfsTypes, Error, PeerId};
+use ipfs::{Ipfs, IpfsTypes};
 use super::support::{with_ipfs, StringError};
 
 #[derive(Default)]
 pub struct Pubsub {
     subscriptions: Mutex<HashMap<String, broadcast::Sender<Result<PreformattedJsonMessage, StreamError>>>>,
-    //shoveler_tx: mpsc::Sender<(Subscription, broadcast::Sender<PubsubMessage)>>,
 }
 
 pub fn routes<T: IpfsTypes>(ipfs: &Ipfs<T>) -> impl warp::Filter<Extract = impl warp::Reply, Error = warp::Rejection> + Clone {
@@ -256,7 +254,7 @@ impl<S> warp::Reply for StreamResponse<S>
         // while it may seem like the S::Error is handled somehow it currently just means the
         // response will stop. hopefully later it can be used to become trailer headers.
         let mut resp = warp::reply::Response::new(Body::wrap_stream(self.0.into_stream()));
-        let mut headers = resp.headers_mut();
+        let headers = resp.headers_mut();
 
         // FIXME: unable to send this header with warp/hyper right now
         headers.insert(TRAILER, HeaderValue::from_static("X-Stream-Error"));

--- a/http/src/v0/pubsub.rs
+++ b/http/src/v0/pubsub.rs
@@ -202,15 +202,15 @@ async fn shovel<T: IpfsTypes>(
         topic
     );
 
-    // needs to be mut so that we resubscribe
-    let one_second = Duration::from_millis(1000);
+    // related conformance test waits for 100ms
+    let check_every = Duration::from_millis(50);
 
     loop {
         // has the underlying stream been stopped by directly calling
         // `Ipfs::pubsub_unsubscribe`
         let mut unsubscribed = true;
         loop {
-            let next = match timeout(one_second, shoveled.next()).await {
+            let next = match timeout(check_every, shoveled.next()).await {
                 Ok(Some(next)) => preformat(next),
                 Ok(None) => break,
                 Err(_) => {

--- a/http/src/v0/pubsub.rs
+++ b/http/src/v0/pubsub.rs
@@ -44,7 +44,7 @@ async fn inner_peers<T: IpfsTypes>(
     topic: Option<String>,
 ) -> Result<impl warp::Reply, warp::Rejection> {
     let peers = ipfs
-        .pubsub_peers(topic.as_ref().map(String::as_str))
+        .pubsub_peers(topic.as_deref())
         .await
         .map_err(|e| warp::reject::custom(StringError::from(e)))?;
 

--- a/http/src/v0/pubsub.rs
+++ b/http/src/v0/pubsub.rs
@@ -17,10 +17,13 @@ pub struct Pubsub {
 }
 
 pub fn routes<T: IpfsTypes>(ipfs: &Ipfs<T>) -> impl warp::Filter<Extract = impl warp::Reply, Error = warp::Rejection> + Clone {
-    peers(ipfs)
-        .or(list_subscriptions(ipfs))
-        .or(publish(ipfs))
-        .or(subscribe(ipfs, Default::default()))
+    warp::path("pubsub")
+        .and(
+            peers(ipfs)
+                .or(list_subscriptions(ipfs))
+                .or(publish(ipfs))
+                .or(subscribe(ipfs, Default::default()))
+        )
 }
 
 pub fn peers<T: IpfsTypes>(ipfs: &Ipfs<T>) -> impl warp::Filter<Extract = impl warp::Reply, Error = warp::Rejection> + Clone {

--- a/http/src/v0/pubsub.rs
+++ b/http/src/v0/pubsub.rs
@@ -165,8 +165,8 @@ async fn inner_subscribe<T: IpfsTypes>(
 
             // using broadcast channel should allow us have N concurrent subscribes and
             // preformatted json should give us good enough performance. this channel can last over
-            // multiple subscriptions and unsubscriptions
-            let (tx, rx) = broadcast::channel::<Result<PreformattedJsonMessage, StreamError>>(4);
+            // multiple subscriptions and unsubscriptions.
+            let (tx, rx) = broadcast::channel::<Result<PreformattedJsonMessage, StreamError>>(16);
 
             // this will be used to create more subscriptions
             ve.insert(tx.clone());

--- a/http/src/v0/support.rs
+++ b/http/src/v0/support.rs
@@ -124,7 +124,7 @@ pub async fn recover_as_message_response(
                 .to_json_reply(),
         );
         status = StatusCode::BAD_REQUEST;
-    } else if let Some(e) = err.find::<NonUtf8Topic>() {
+    } else if let Some(_) = err.find::<NonUtf8Topic>() {
         resp = Box::new(
             MessageKind::Error
                 .with_code(0)

--- a/http/src/v0/support.rs
+++ b/http/src/v0/support.rs
@@ -124,7 +124,7 @@ pub async fn recover_as_message_response(
                 .to_json_reply(),
         );
         status = StatusCode::BAD_REQUEST;
-    } else if let Some(_) = err.find::<NonUtf8Topic>() {
+    } else if err.find::<NonUtf8Topic>().is_some() {
         resp = Box::new(
             MessageKind::Error
                 .with_code(0)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -42,8 +42,8 @@ use self::config::ConfigFile;
 use self::dag::IpldDag;
 pub use self::error::Error;
 use self::ipns::Ipns;
+pub use self::p2p::pubsub::{PubsubMessage, SubscriptionStream};
 pub use self::p2p::Connection;
-pub use self::p2p::PubsubMessage;
 pub use self::p2p::SwarmTypes;
 use self::p2p::{create_swarm, SwarmOptions, TSwarm};
 pub use self::path::IpfsPath;
@@ -221,7 +221,7 @@ enum IpfsEvent {
     Disconnect(Multiaddr, Channel<()>),
     /// Request background task to return the listened and external addresses
     GetAddresses(OneshotSender<Vec<Multiaddr>>),
-    PubsubSubscribe(String, OneshotSender<Option<p2p::pubsub::StreamImpl>>),
+    PubsubSubscribe(String, OneshotSender<Option<SubscriptionStream>>),
     PubsubUnsubscribe(String, OneshotSender<bool>),
     PubsubPublish(String, Vec<u8>, OneshotSender<()>),
     PubsubPeers(Option<String>, OneshotSender<Vec<PeerId>>),
@@ -414,10 +414,7 @@ impl<Types: IpfsTypes> Ipfs<Types> {
     /// Subscribes to a given topic. Can be done at most once without unsubscribing in the between.
     /// The subscription can be unsubscribed by dropping the stream or calling
     /// [`pubsub_unsubscribe`].
-    pub async fn pubsub_subscribe(
-        &self,
-        topic: &str,
-    ) -> Result<impl futures::stream::Stream<Item = Arc<PubsubMessage>> + fmt::Debug, Error> {
+    pub async fn pubsub_subscribe(&self, topic: &str) -> Result<SubscriptionStream, Error> {
         let (tx, rx) = oneshot_channel();
 
         self.to_task

--- a/src/p2p/mod.rs
+++ b/src/p2p/mod.rs
@@ -12,7 +12,6 @@ mod behaviour;
 pub(crate) mod pubsub;
 mod swarm;
 mod transport;
-pub use pubsub::PubsubMessage;
 
 pub use swarm::Connection;
 

--- a/src/p2p/pubsub.rs
+++ b/src/p2p/pubsub.rs
@@ -1,5 +1,5 @@
 use futures::channel::mpsc as channel;
-use futures::stream::Stream;
+use futures::stream::{FusedStream, Stream};
 
 use std::collections::HashMap;
 use std::fmt;
@@ -58,48 +58,65 @@ impl From<FloodsubMessage> for PubsubMessage {
     }
 }
 
-pub(crate) type StreamImpl = UnsubscribeOnDrop<channel::UnboundedReceiver<Arc<PubsubMessage>>>;
+/// Stream of a pubsub messages. Implements [`FusedStream`].
+pub struct SubscriptionStream {
+    on_drop: Option<channel::UnboundedSender<String>>,
+    topic: Option<String>,
+    inner: channel::UnboundedReceiver<Arc<PubsubMessage>>,
+}
 
-pub struct UnsubscribeOnDrop<T>(channel::UnboundedSender<String>, Option<String>, T);
-
-impl<T> Drop for UnsubscribeOnDrop<T> {
+impl Drop for SubscriptionStream {
     fn drop(&mut self) {
-        // the topic option allows us to disable this unsubscribe on drop once the stream has
-        // ended. TODO: it would also be easy to implement FusedStream based on the state of the
-        // option, if that is ever needed.
-        if let Some(topic) = self.1.take() {
-            // ignore errors
-            let _ = self.0.unbounded_send(topic);
+        // the on_drop option allows us to disable this unsubscribe on drop once the stream has
+        // ended.
+        if let Some(sender) = self.on_drop.take() {
+            if let Some(topic) = self.topic.take() {
+                let _ = sender.unbounded_send(topic);
+            }
         }
     }
 }
 
-impl<T> fmt::Debug for UnsubscribeOnDrop<T> {
+impl fmt::Debug for SubscriptionStream {
     fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
-        write!(
-            fmt,
-            "UnsubscribeOnDrop<{}>({:?})",
-            std::any::type_name::<T>(),
-            self.1
-        )
+        if let Some(topic) = self.topic.as_ref() {
+            write!(
+                fmt,
+                "SubscriptionStream {{ topic: {:?}, is_terminated: {} }}",
+                topic,
+                self.is_terminated()
+            )
+        } else {
+            write!(
+                fmt,
+                "SubscriptionStream {{ is_terminated: {} }}",
+                self.is_terminated()
+            )
+        }
     }
 }
 
-impl<T: Stream + Unpin> Stream for UnsubscribeOnDrop<T> {
-    type Item = T::Item;
+impl Stream for SubscriptionStream {
+    type Item = Arc<PubsubMessage>;
 
     fn poll_next(mut self: Pin<&mut Self>, ctx: &mut Context) -> Poll<Option<Self::Item>> {
-        let inner = &mut self.as_mut().2;
-        let inner = Pin::new(inner);
-        match inner.poll_next(ctx) {
+        use futures::stream::StreamExt;
+        let inner = &mut self.as_mut().inner;
+        match inner.poll_next_unpin(ctx) {
             Poll::Ready(None) => {
                 // no need to unsubscribe on drop as the stream has already ended, likely via
                 // unsubscribe call.
-                self.1.take();
+                self.on_drop.take();
                 Poll::Ready(None)
             }
             other => other,
         }
+    }
+}
+
+impl FusedStream for SubscriptionStream {
+    fn is_terminated(&self) -> bool {
+        self.on_drop.is_none()
     }
 }
 
@@ -118,7 +135,7 @@ impl Pubsub {
 
     /// Subscribes to an currently unsubscribed topic.
     /// Returns a receiver for messages sent to the topic or `None` if subscription existed already
-    pub fn subscribe(&mut self, topic: impl Into<String>) -> Option<StreamImpl> {
+    pub fn subscribe(&mut self, topic: impl Into<String>) -> Option<SubscriptionStream> {
         use std::collections::hash_map::Entry;
 
         let topic = Topic::new(topic);
@@ -137,11 +154,11 @@ impl Pubsub {
 
                 let name = ve.key().id().to_string();
                 ve.insert(tx);
-                Some(UnsubscribeOnDrop(
-                    self.unsubscriptions.0.clone(),
-                    Some(name),
-                    rx,
-                ))
+                Some(SubscriptionStream {
+                    on_drop: Some(self.unsubscriptions.0.clone()),
+                    topic: Some(name),
+                    inner: rx,
+                })
             }
             Entry::Occupied(_) => None,
         }

--- a/src/p2p/pubsub.rs
+++ b/src/p2p/pubsub.rs
@@ -8,7 +8,7 @@ use std::sync::Arc;
 use std::task::{Context, Poll};
 
 use libp2p::core::{ConnectedPoint, Multiaddr, PeerId};
-use libp2p::floodsub::{Floodsub, FloodsubEvent, FloodsubMessage, Topic};
+use libp2p::floodsub::{Floodsub, FloodsubEvent, FloodsubMessage, FloodsubOptions, Topic};
 use libp2p::swarm::{NetworkBehaviour, NetworkBehaviourAction, PollParameters, ProtocolsHandler};
 
 /// Currently a thin wrapper around Floodsub, perhaps supporting both Gossipsub and Floodsub later.
@@ -125,10 +125,12 @@ impl Pubsub {
     /// top of the floodsub.
     pub fn new(peer_id: PeerId) -> Self {
         let (tx, rx) = channel::unbounded();
+        let mut opts = FloodsubOptions::new(peer_id);
+        opts.subscribe_local_messages = true;
         Pubsub {
             streams: HashMap::new(),
             peers: HashMap::new(),
-            floodsub: Floodsub::new(peer_id),
+            floodsub: Floodsub::from_options(opts),
             unsubscriptions: (tx, rx),
         }
     }


### PR DESCRIPTION
Adds the `/api/v0/pubsub` endpoints. Passing the conformance tests requires a modified libp2p-floodsub which I haven't yet pushed. The required functionality is getting the locally sent messages as if they were received over the swarm published over to subscriber(s).

This depends on #118 so creating this as a draft.

Things still to do:

 - [x] publish and create PR libp2p created https://github.com/libp2p/rust-libp2p/pull/1520
 - [ ] maybe have a drop `tokio::sync::watch` for the pubsub responses instead of timeout?

The latter has not been done. I am currently more interested in lowering the broadcast channel size to less than what the conformance tests use by getting some backpressure in, but that'll have to be later.