### PR TITLE
Fix flaky pubsub test

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -268,9 +268,11 @@ dependencies = [
  "libp2p-core 0.16.0 (git+https://github.com/koivunej/rust-libp2p.git?branch=v0.16.2-with-floodsub-opts)",
  "libp2p-swarm 0.16.1 (git+https://github.com/koivunej/rust-libp2p.git?branch=v0.16.2-with-floodsub-opts)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "multihash 0.10.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "prost 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "prost-build 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "thiserror 1.0.11 (registry+https://github.com/rust-lang/crates.io-index)",
+ "unsigned-varint 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]

--- a/src/p2p/pubsub.rs
+++ b/src/p2p/pubsub.rs
@@ -28,7 +28,7 @@ pub struct Pubsub {
 }
 
 /// Adaptation hopefully supporting somehow both Floodsub and Gossipsub Messages in the future
-#[derive(Debug, PartialEq, Eq)]
+#[derive(Debug, PartialEq, Eq, Clone)]
 pub struct PubsubMessage {
     pub source: PeerId,
     pub data: Vec<u8>,

--- a/tests/pubsub.rs
+++ b/tests/pubsub.rs
@@ -95,7 +95,9 @@ async fn publish_between_two_nodes() {
     for st in &mut [b_msgs.by_ref(), a_msgs.by_ref()] {
         let actual = st
             .take(2)
-            .map(|msg| Arc::try_unwrap(msg).expect("single subscriber"))
+            // Arc::try_unwrap will fail sometimes here as the sender side in src/p2p/pubsub.rs:305
+            // can still be looping
+            .map(|msg| (*msg).clone())
             .map(|msg| (msg.topics, msg.source, msg.data))
             .collect::<HashSet<_>>()
             .await;

--- a/tests/pubsub.rs
+++ b/tests/pubsub.rs
@@ -48,7 +48,6 @@ async fn can_publish_without_subscribing() {
 async fn publish_between_two_nodes() {
     use futures::stream::StreamExt;
     use std::collections::HashSet;
-    use std::sync::Arc;
 
     let ((a, a_id), (b, b_id)) = two_connected_nodes().await;
 


### PR DESCRIPTION
Also including a possibly leftover update to Cargo.lock from the #123 ... I think?Perhaps we should have a CI check that the lock file is unchanged after build?