### PR TITLE
Fix subscription deadlock

### DIFF
--- a/src/repo/mod.rs
+++ b/src/repo/mod.rs
@@ -110,9 +110,7 @@ impl<TRepoTypes: RepoTypes> Repo<TRepoTypes> {
     /// Shutdowns the repo, cancelling any pending subscriptions; Likely going away after some
     /// refactoring, see notes on [`Ipfs::exit_daemon`].
     pub async fn shutdown(&self) {
-        self.subscriptions.lock()
-            .await
-            .shutdown();
+        self.subscriptions.lock().await.shutdown();
     }
 
     pub async fn init(&self) -> Result<(), Error> {

--- a/src/repo/mod.rs
+++ b/src/repo/mod.rs
@@ -107,6 +107,14 @@ impl<TRepoTypes: RepoTypes> Repo<TRepoTypes> {
         )
     }
 
+    /// Shutdowns the repo, cancelling any pending subscriptions; Likely going away after some
+    /// refactoring, see notes on [`Ipfs::exit_daemon`].
+    pub async fn shutdown(&self) {
+        self.subscriptions.lock()
+            .await
+            .shutdown();
+    }
+
     pub async fn init(&self) -> Result<(), Error> {
         let f1 = self.block_store.init();
         let f2 = self.data_store.init();
@@ -163,7 +171,7 @@ impl<TRepoTypes: RepoTypes> Repo<TRepoTypes> {
                 .send(RepoEvent::WantBlock(cid.clone()))
                 .await
                 .ok();
-            Ok(subscription.await)
+            Ok(subscription.await?)
         }
     }
 

--- a/src/subscription.rs
+++ b/src/subscription.rs
@@ -20,7 +20,8 @@ impl<TReq: Debug + Eq + Hash, TRes: Debug> fmt::Debug for SubscriptionRegistry<T
             std::any::type_name::<Self>(),
             std::any::type_name::<TReq>(),
             std::any::type_name::<TRes>(),
-            self.subscriptions)
+            self.subscriptions
+        )
     }
 }
 
@@ -72,7 +73,8 @@ impl<TReq: Debug + Eq + Hash, TRes: Debug> SubscriptionRegistry<TReq, TRes> {
         log::trace!(
             "Cancelled {} subscriptions and {} are pending (not immediatedly locked)",
             cancelled,
-            pending.len());
+            pending.len()
+        );
 
         let remaining = pending.len();
 
@@ -85,7 +87,8 @@ impl<TReq: Debug + Eq + Hash, TRes: Debug> SubscriptionRegistry<TReq, TRes> {
         log::debug!(
             "Remaining {} pending subscriptions cancelled (total of {})",
             remaining,
-            cancelled + remaining);
+            cancelled + remaining
+        );
     }
 }
 
@@ -125,9 +128,14 @@ impl<TResult> fmt::Debug for Subscription<TResult> {
             fmt,
             "Subscription<{}>(result: {}, wakers: {}, cancelled: {})",
             std::any::type_name::<TResult>(),
-            if self.result.is_some() { "Some(_)" } else { "None" },
+            if self.result.is_some() {
+                "Some(_)"
+            } else {
+                "None"
+            },
             self.wakers.len(),
-            self.cancelled)
+            self.cancelled
+        )
     }
 }
 

--- a/src/subscription.rs
+++ b/src/subscription.rs
@@ -7,10 +7,21 @@ use std::collections::HashMap;
 use std::fmt;
 use std::sync::{Arc, Mutex};
 
-#[derive(Debug)]
 pub struct SubscriptionRegistry<TReq: Debug + Eq + Hash, TRes: Debug> {
     subscriptions: HashMap<TReq, Arc<Mutex<Subscription<TRes>>>>,
     cancelled: bool,
+}
+
+impl<TReq: Debug + Eq + Hash, TRes: Debug> fmt::Debug for SubscriptionRegistry<TReq, TRes> {
+    fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
+        write!(
+            fmt,
+            "{}<{}, {}>(subscriptions: {:?})",
+            std::any::type_name::<Self>(),
+            std::any::type_name::<TReq>(),
+            std::any::type_name::<TRes>(),
+            self.subscriptions)
+    }
 }
 
 impl<TReq: Debug + Eq + Hash, TRes: Debug> SubscriptionRegistry<TReq, TRes> {
@@ -102,11 +113,22 @@ impl fmt::Display for Cancelled {
 
 impl std::error::Error for Cancelled {}
 
-#[derive(Debug)]
 pub struct Subscription<TResult> {
     result: Option<TResult>,
     wakers: Vec<Waker>,
     cancelled: bool,
+}
+
+impl<TResult> fmt::Debug for Subscription<TResult> {
+    fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
+        write!(
+            fmt,
+            "Subscription<{}>(result: {}, wakers: {}, cancelled: {})",
+            std::any::type_name::<TResult>(),
+            if self.result.is_some() { "Some(_)" } else { "None" },
+            self.wakers.len(),
+            self.cancelled)
+    }
 }
 
 impl<TResult> Subscription<TResult> {


### PR DESCRIPTION
This fixes the deadlock found when working on the WIP #126 code.

I saw you already refactored these subscription registries out and replaced them with oneshot channels. I think that is a good idea but didn't investigate it too deeply, as they'll handle dropping and cancelling issue better. 

I'll follow up this with #126 new features on top of this.