### PR TITLE
Add bitswap block apis

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1246,11 +1246,13 @@ dependencies = [
 name = "ipfs-http"
 version = "0.1.0"
 dependencies = [
+ "cid 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "env_logger 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "ipfs 0.1.0",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "multibase 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "multihash 0.10.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "openssl 0.10.28 (registry+https://github.com/rust-lang/crates.io-index)",
  "percent-encoding 2.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "prost 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/bitswap/src/behaviour.rs
+++ b/bitswap/src/behaviour.rs
@@ -39,7 +39,7 @@ pub struct Stats {
     pub received_blocks: u64,
     pub received_data: u64,
     pub duplicate_blocks: u64,
-    pub duplicate_data: u64
+    pub duplicate_data: u64,
 }
 
 impl<TStrategy> Bitswap<TStrategy> {
@@ -57,7 +57,10 @@ impl<TStrategy> Bitswap<TStrategy> {
 
     /// Return the wantlist of the local node
     pub fn local_wantlist(&self) -> Vec<(Cid, Priority)> {
-        self.wanted_blocks.iter().map(|(cid, prio)| (cid.clone(), *prio)).collect()
+        self.wanted_blocks
+            .iter()
+            .map(|(cid, prio)| (cid.clone(), *prio))
+            .collect()
     }
 
     /// Return the wantlist of a peer, if known
@@ -67,15 +70,17 @@ impl<TStrategy> Bitswap<TStrategy> {
 
     pub fn stats(&self) -> Stats {
         // we currently do not remove ledgers so this is ... good enough
-        self.connected_peers.values().fold(Stats::default(), |mut acc, ledger| {
-            acc.sent_blocks += ledger.sent_blocks;
-            acc.sent_data += ledger.sent_data;
-            acc.received_blocks += ledger.received_blocks;
-            acc.received_data += ledger.received_data;
-            acc.duplicate_blocks += ledger.duplicate_blocks;
-            acc.duplicate_data += ledger.duplicate_data;
-            acc
-        })
+        self.connected_peers
+            .values()
+            .fold(Stats::default(), |mut acc, ledger| {
+                acc.sent_blocks += ledger.sent_blocks;
+                acc.sent_data += ledger.sent_data;
+                acc.received_blocks += ledger.received_blocks;
+                acc.received_data += ledger.received_data;
+                acc.duplicate_blocks += ledger.duplicate_blocks;
+                acc.duplicate_data += ledger.duplicate_data;
+                acc
+            })
     }
 
     pub fn peers(&self) -> Vec<PeerId> {
@@ -269,11 +274,15 @@ impl<TStrategy: Strategy> NetworkBehaviour for Bitswap<TStrategy> {
 
         match inner {
             StrategyEvent::Send { peer_id, block } => self.send_block(peer_id, block),
-            StrategyEvent::NewBlockStored { source, bytes } => if let Some(ledger) = self.connected_peers.get_mut(&source) {
-                ledger.update_incoming_stored(bytes)
-            },
-            StrategyEvent::DuplicateBlockReceived { source, bytes } => if let Some(ledger) = self.connected_peers.get_mut(&source) {
-                ledger.update_incoming_duplicate(bytes)
+            StrategyEvent::NewBlockStored { source, bytes } => {
+                if let Some(ledger) = self.connected_peers.get_mut(&source) {
+                    ledger.update_incoming_stored(bytes)
+                }
+            }
+            StrategyEvent::DuplicateBlockReceived { source, bytes } => {
+                if let Some(ledger) = self.connected_peers.get_mut(&source) {
+                    ledger.update_incoming_duplicate(bytes)
+                }
             }
         }
 

--- a/bitswap/src/behaviour.rs
+++ b/bitswap/src/behaviour.rs
@@ -45,6 +45,16 @@ impl<TStrategy> Bitswap<TStrategy> {
         }
     }
 
+    /// Return the wantlist of the local node
+    pub fn local_wantlist(&self) -> Vec<(Cid, Priority)> {
+        self.wanted_blocks.iter().map(|(cid, prio)| (cid.clone(), *prio)).collect()
+    }
+
+    /// Return the wantlist of a peer, if known
+    pub fn peer_wantlist(&self, peer: &PeerId) -> Option<Vec<(Cid, Priority)>> {
+        self.connected_peers.get(peer).map(Ledger::wantlist)
+    }
+
     /// Connect to peer.
     ///
     /// Called from Kademlia behaviour.

--- a/bitswap/src/block.rs
+++ b/bitswap/src/block.rs
@@ -18,4 +18,8 @@ impl Block {
     pub fn data(&self) -> &[u8] {
         &self.data
     }
+
+    pub fn to_vec(self) -> Vec<u8> {
+        self.data.into()
+    }
 }

--- a/bitswap/src/block.rs
+++ b/bitswap/src/block.rs
@@ -19,7 +19,7 @@ impl Block {
         &self.data
     }
 
-    pub fn to_vec(self) -> Vec<u8> {
+    pub fn into_vec(self) -> Vec<u8> {
         self.data.into()
     }
 }

--- a/bitswap/src/ledger.rs
+++ b/bitswap/src/ledger.rs
@@ -89,7 +89,10 @@ impl Ledger {
 
     /// Returns the blocks wanted by the peer in unspecified order
     pub fn wantlist(&self) -> Vec<(Cid, Priority)> {
-        self.received_want_list.iter().map(|(cid, prio)| (cid.clone(), *prio)).collect()
+        self.received_want_list
+            .iter()
+            .map(|(cid, prio)| (cid.clone(), *prio))
+            .collect()
     }
 }
 

--- a/bitswap/src/ledger.rs
+++ b/bitswap/src/ledger.rs
@@ -70,6 +70,11 @@ impl Ledger {
             self.received_want_list.insert(cid.to_owned(), *priority);
         }
     }
+
+    /// Returns the blocks wanted by the peer in unspecified order
+    pub fn wantlist(&self) -> Vec<(Cid, Priority)> {
+        self.received_want_list.iter().map(|(cid, prio)| (cid.clone(), *prio)).collect()
+    }
 }
 
 #[derive(Debug, Clone, PartialEq)]

--- a/bitswap/src/lib.rs
+++ b/bitswap/src/lib.rs
@@ -10,11 +10,11 @@ mod prefix;
 mod protocol;
 mod strategy;
 
-pub use self::behaviour::Bitswap;
+pub use self::behaviour::{Bitswap, Stats};
 pub use self::block::Block;
 pub use self::error::BitswapError;
 pub use self::ledger::Priority;
-pub use self::strategy::{AltruisticStrategy, BitswapStore, Strategy};
+pub use self::strategy::{AltruisticStrategy, BitswapStore, Strategy, BlockPut};
 
 mod bitswap_pb {
     include!(concat!(env!("OUT_DIR"), "/bitswap_pb.rs"));

--- a/bitswap/src/lib.rs
+++ b/bitswap/src/lib.rs
@@ -14,7 +14,7 @@ pub use self::behaviour::{Bitswap, Stats};
 pub use self::block::Block;
 pub use self::error::BitswapError;
 pub use self::ledger::Priority;
-pub use self::strategy::{AltruisticStrategy, BitswapStore, Strategy, BlockPut};
+pub use self::strategy::{AltruisticStrategy, BitswapStore, BlockPut, Strategy};
 
 mod bitswap_pb {
     include!(concat!(env!("OUT_DIR"), "/bitswap_pb.rs"));

--- a/bitswap/src/strategy.rs
+++ b/bitswap/src/strategy.rs
@@ -2,10 +2,10 @@ use crate::block::Block;
 use crate::ledger::Priority;
 use async_std::task;
 use async_trait::async_trait;
+use futures::channel::mpsc::{unbounded, UnboundedReceiver as Receiver, UnboundedSender as Sender};
 use libipld::cid::Cid;
 use libp2p_core::PeerId;
 use std::sync::{Arc, Mutex};
-use futures::channel::mpsc::{unbounded, UnboundedSender as Sender, UnboundedReceiver as Receiver};
 use std::task::{Context, Poll};
 
 #[derive(Debug, PartialEq, Eq)]
@@ -106,7 +106,7 @@ impl Strategy for AltruisticStrategy {
                         e
                     );
                     return;
-                },
+                }
             };
 
             let _ = sender.unbounded_send(evt);
@@ -117,7 +117,10 @@ impl Strategy for AltruisticStrategy {
     fn poll(&self, ctx: &mut Context) -> Poll<Option<StrategyEvent>> {
         use futures::stream::StreamExt;
 
-        let mut g = self.events.try_lock().expect("Failed to acquire the uncontended mutex right away");
+        let mut g = self
+            .events
+            .try_lock()
+            .expect("Failed to acquire the uncontended mutex right away");
 
         g.poll_next_unpin(ctx)
     }

--- a/http/Cargo.toml
+++ b/http/Cargo.toml
@@ -27,3 +27,5 @@ percent-encoding = "*"
 openssl = "0.10"
 
 prost = "0.6.1"
+cid = "0.4"
+multihash = "0.10"

--- a/http/src/main.rs
+++ b/http/src/main.rs
@@ -25,7 +25,7 @@ fn main() {
     if std::env::var_os("RUST_LOG").is_none() {
         // FIXME: see if tracing could be used as the frontend for log macros
         // FIXME: use log macros here as well
-        std::env::set_var("RUST_LOG", "ipfs-http=trace,ipfs=trace");
+        std::env::set_var("RUST_LOG", "ipfs-http=trace,ipfs=trace,bitswap=trace");
     }
 
     env_logger::init();

--- a/http/src/main.rs
+++ b/http/src/main.rs
@@ -126,6 +126,7 @@ fn main() {
     };
 
     println!("IPFS_PATH: {:?}", home);
+    println!("Process id: {}", std::process::id());
 
     // TODO: sigterm should initiate graceful shutdown, second time should shutdown right now
     // NOTE: sigkill ... well surely it will stop the process right away

--- a/http/src/v0.rs
+++ b/http/src/v0.rs
@@ -5,6 +5,8 @@ pub mod id;
 pub mod pubsub;
 pub mod swarm;
 pub mod version;
+pub mod block;
+pub mod bitswap;
 
 pub mod support;
 pub use support::recover_as_message_response;
@@ -32,7 +34,10 @@ where
             // Placeholder paths
             // https://docs.rs/warp/0.2.2/warp/macro.path.html#path-prefixes
             .or(warp::path!("add").and_then(not_implemented))
-            .or(warp::path!("bitswap" / ..).and_then(not_implemented))
+            .or(bitswap::wantlist(ipfs))
+            .or(bitswap::stat(ipfs))
+            .or(block::get(ipfs))
+            .or(block::put(ipfs))
             .or(warp::path!("block" / ..).and_then(not_implemented))
             .or(warp::path!("bootstrap" / ..).and_then(not_implemented))
             .or(warp::path!("config" / ..).and_then(not_implemented))

--- a/http/src/v0.rs
+++ b/http/src/v0.rs
@@ -1,12 +1,12 @@
 use ipfs::{Ipfs, IpfsTypes};
 use std::convert::Infallible;
 
+pub mod bitswap;
+pub mod block;
 pub mod id;
 pub mod pubsub;
 pub mod swarm;
 pub mod version;
-pub mod block;
-pub mod bitswap;
 
 pub mod support;
 pub use support::recover_as_message_response;

--- a/http/src/v0/bitswap.rs
+++ b/http/src/v0/bitswap.rs
@@ -1,0 +1,99 @@
+use crate::v0::support::{with_ipfs, InvalidPeerId, StringError};
+use ipfs::{BitswapStats, Ipfs, IpfsTypes};
+use serde::{Deserialize, Serialize};
+use serde_json::{json, Value};
+use warp::{path, query, reply, Filter, Rejection, Reply};
+
+#[derive(Debug, Deserialize)]
+pub struct WantlistQuery {
+    peer: Option<String>,
+}
+
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "PascalCase")]
+pub struct WantlistResponse {
+    keys: Vec<Value>,
+}
+
+async fn wantlist_query<T: IpfsTypes>(ipfs: Ipfs<T>, query: WantlistQuery) -> Result<impl Reply, Rejection> {
+    let peer_id = if let Some(peer_id) = query.peer {
+        let peer_id = peer_id.parse().map_err(|_| InvalidPeerId)?;
+        Some(peer_id)
+    } else {
+        None
+    };
+    let cids = ipfs
+        .bitswap_wantlist(peer_id)
+        .await
+        .map_err(StringError::from)?;
+    let keys = cids
+        .into_iter()
+        .map(|(cid, _)| json!({"/": cid.to_string()}))
+        .collect();
+    let response = WantlistResponse { keys };
+    Ok(reply::json(&response))
+}
+
+pub fn wantlist<T: IpfsTypes>(ipfs: &Ipfs<T>) -> impl Filter<Extract = impl Reply, Error = Rejection> + Clone {
+    path!("bitswap" / "wantlist")
+        .and(with_ipfs(ipfs))
+        .and(query::<WantlistQuery>())
+        .and_then(wantlist_query)
+}
+
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "PascalCase")]
+pub struct StatResponse {
+    blocks_received: u64,
+    blocks_sent: u64,
+    data_received: u64,
+    data_sent: u64,
+    dup_blks_received: u64,
+    dup_data_received: u64,
+    messages_received: u64,
+    peers: Vec<String>,
+    provide_buf_len: i32,
+    wantlist: Vec<Value>,
+}
+
+impl From<BitswapStats> for StatResponse {
+    fn from(stats: BitswapStats) -> Self {
+        let wantlist = stats
+            .wantlist
+            .into_iter()
+            .map(|(cid, _)| json!({"/": cid.to_string()}))
+            .collect();
+        let peers = stats
+            .peers
+            .into_iter()
+            .map(|peer_id| peer_id.to_string())
+            .collect();
+        Self {
+            blocks_received: stats.blocks_received,
+            blocks_sent: stats.blocks_sent,
+            data_received: stats.data_received,
+            data_sent: stats.data_sent,
+            dup_blks_received: stats.dup_blks_received,
+            dup_data_received: stats.dup_data_received,
+            peers,
+            wantlist,
+            messages_received: 0,
+            provide_buf_len: 0,
+        }
+    }
+}
+
+async fn stat_query<T: IpfsTypes>(ipfs: Ipfs<T>) -> Result<impl Reply, Rejection> {
+    let stats: StatResponse = ipfs
+        .bitswap_stats()
+        .await
+        .map_err(StringError::from)?
+        .into();
+    Ok(reply::json(&stats))
+}
+
+pub fn stat<T: IpfsTypes>(ipfs: &Ipfs<T>) -> impl Filter<Extract = impl Reply, Error = Rejection> + Clone {
+    path!("bitswap" / "stat")
+        .and(with_ipfs(ipfs))
+        .and_then(stat_query)
+}

--- a/http/src/v0/bitswap.rs
+++ b/http/src/v0/bitswap.rs
@@ -15,7 +15,10 @@ pub struct WantlistResponse {
     keys: Vec<Value>,
 }
 
-async fn wantlist_query<T: IpfsTypes>(ipfs: Ipfs<T>, query: WantlistQuery) -> Result<impl Reply, Rejection> {
+async fn wantlist_query<T: IpfsTypes>(
+    ipfs: Ipfs<T>,
+    query: WantlistQuery,
+) -> Result<impl Reply, Rejection> {
     let peer_id = if let Some(peer_id) = query.peer {
         let peer_id = peer_id.parse().map_err(|_| InvalidPeerId)?;
         Some(peer_id)
@@ -34,7 +37,9 @@ async fn wantlist_query<T: IpfsTypes>(ipfs: Ipfs<T>, query: WantlistQuery) -> Re
     Ok(reply::json(&response))
 }
 
-pub fn wantlist<T: IpfsTypes>(ipfs: &Ipfs<T>) -> impl Filter<Extract = impl Reply, Error = Rejection> + Clone {
+pub fn wantlist<T: IpfsTypes>(
+    ipfs: &Ipfs<T>,
+) -> impl Filter<Extract = impl Reply, Error = Rejection> + Clone {
     path!("bitswap" / "wantlist")
         .and(with_ipfs(ipfs))
         .and(query::<WantlistQuery>())
@@ -92,7 +97,9 @@ async fn stat_query<T: IpfsTypes>(ipfs: Ipfs<T>) -> Result<impl Reply, Rejection
     Ok(reply::json(&stats))
 }
 
-pub fn stat<T: IpfsTypes>(ipfs: &Ipfs<T>) -> impl Filter<Extract = impl Reply, Error = Rejection> + Clone {
+pub fn stat<T: IpfsTypes>(
+    ipfs: &Ipfs<T>,
+) -> impl Filter<Extract = impl Reply, Error = Rejection> + Clone {
     path!("bitswap" / "stat")
         .and(with_ipfs(ipfs))
         .and_then(stat_query)

--- a/http/src/v0/block.rs
+++ b/http/src/v0/block.rs
@@ -1,0 +1,133 @@
+use crate::v0::support::{with_ipfs, InvalidMultipartFormData, StringError};
+use cid::{Codec, Version};
+use futures::stream::StreamExt;
+use ipfs::{Cid, Ipfs, IpfsTypes};
+use serde::{Deserialize, Serialize};
+use warp::{http::Response, multipart, path, query, reply, Filter, Rejection, Reply, Buf};
+
+#[derive(Debug, Deserialize)]
+pub struct GetQuery {
+    arg: String,
+}
+
+async fn get_query<T: IpfsTypes>(mut ipfs: Ipfs<T>, query: GetQuery) -> Result<impl Reply, Rejection> {
+    let cid: Cid = query.arg.parse().map_err(StringError::from)?;
+    let data = ipfs
+        .get_block(&cid)
+        .await
+        .map_err(StringError::from)?
+        .to_vec();
+
+    let response = Response::builder().body(data);
+    Ok(response)
+}
+
+pub fn get<T: IpfsTypes>(ipfs: &Ipfs<T>) -> impl Filter<Extract = impl Reply, Error = Rejection> + Clone {
+    path!("block" / "get")
+        .and(with_ipfs(ipfs))
+        .and(query::<GetQuery>())
+        .and_then(get_query)
+}
+
+#[derive(Debug, Deserialize)]
+pub struct PutQuery {
+    format: Option<String>,
+    mhtype: Option<String>,
+    version: Option<u8>,
+}
+
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "PascalCase")]
+pub struct PutResponse {
+    key: String,
+    size: usize,
+}
+
+async fn put_query<T: IpfsTypes>(
+    mut ipfs: Ipfs<T>,
+    query: PutQuery,
+    mut form: multipart::FormData,
+) -> Result<impl Reply, Rejection> {
+    let format = match query
+        .format
+        .as_ref()
+        .map(|s| s.as_str())
+        .unwrap_or("dag-pb")
+    {
+        "dag-cbor" => Codec::DagCBOR,
+        "dag-pb" => Codec::DagProtobuf,
+        "dag-json" => Codec::DagJSON,
+        "raw" => Codec::Raw,
+        _ => return Err(StringError::from("unknown codec").into()),
+    };
+    let hasher = match query
+        .mhtype
+        .as_ref()
+        .map(|s| s.as_str())
+        .unwrap_or("sha2-256")
+    {
+        "sha2-256" => multihash::Sha2_256::digest,
+        "sha2-512" => multihash::Sha2_512::digest,
+        _ => return Err(StringError::from("unknown hash").into()),
+    };
+    let version = match query.version.unwrap_or(0) {
+        0 => Version::V0,
+        1 => Version::V1,
+        _ => return Err(StringError::from("invalid cid version").into()),
+    };
+    let mut buf = form
+        .next()
+        .await
+        .ok_or(InvalidMultipartFormData)?
+        .map_err(|_| InvalidMultipartFormData)?
+        .data()
+        .await
+        .ok_or(InvalidMultipartFormData)?
+        .map_err(|_| InvalidMultipartFormData)?;
+    let data = buf.to_bytes().as_ref().to_vec().into_boxed_slice();
+    let digest = hasher(&data);
+    let cid = Cid::new(version, format, digest).map_err(StringError::from)?;
+    let response = PutResponse {
+        key: cid.to_string(),
+        size: data.len(),
+    };
+    let block = ipfs::Block { cid, data };
+    ipfs.put_block(block).await.map_err(StringError::from)?;
+    Ok(reply::json(&response))
+}
+
+pub fn put<T: IpfsTypes>(ipfs: &Ipfs<T>) -> impl Filter<Extract = impl Reply, Error = Rejection> + Clone {
+    path!("block" / "put")
+        .and(with_ipfs(ipfs))
+        .and(query::<PutQuery>())
+        .and(multipart::form())
+        .and_then(put_query)
+}
+
+#[derive(Debug, Deserialize)]
+pub struct RmQuery {}
+
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "PascalCase")]
+pub struct RmResponse {}
+
+async fn rm_query<T: IpfsTypes>(_ipfs: Ipfs<T>, _query: RmQuery) -> Result<impl Reply, Rejection> {
+    //let _data = ipfs.put_block(query.cid).await
+    //    .map_err(|e| reject::custom(StringError::from(e)))?;
+    let response = RmResponse {};
+    Ok(reply::json(&response))
+}
+
+pub fn rm<T: IpfsTypes>(ipfs: &Ipfs<T>) -> impl Filter<Extract = impl Reply, Error = Rejection> + Clone {
+    path!("block" / "rm")
+        .and(with_ipfs(ipfs))
+        .and(query::<RmQuery>())
+        .and_then(rm_query)
+}
+
+pub fn stat<T: IpfsTypes>(ipfs: &Ipfs<T>) -> impl Filter<Extract = impl Reply, Error = Rejection> + Clone {
+    path!("block" / "stat")
+        .and(with_ipfs(ipfs))
+        .and(query::<RmQuery>())
+        .and_then(rm_query)
+}

--- a/http/src/v0/block.rs
+++ b/http/src/v0/block.rs
@@ -19,7 +19,7 @@ async fn get_query<T: IpfsTypes>(
         .get_block(&cid)
         .await
         .map_err(StringError::from)?
-        .to_vec();
+        .into_vec();
 
     let response = Response::builder().body(data);
     Ok(response)

--- a/http/src/v0/block.rs
+++ b/http/src/v0/block.rs
@@ -3,14 +3,17 @@ use cid::{Codec, Version};
 use futures::stream::StreamExt;
 use ipfs::{Cid, Ipfs, IpfsTypes};
 use serde::{Deserialize, Serialize};
-use warp::{http::Response, multipart, path, query, reply, Filter, Rejection, Reply, Buf};
+use warp::{http::Response, multipart, path, query, reply, Buf, Filter, Rejection, Reply};
 
 #[derive(Debug, Deserialize)]
 pub struct GetQuery {
     arg: String,
 }
 
-async fn get_query<T: IpfsTypes>(mut ipfs: Ipfs<T>, query: GetQuery) -> Result<impl Reply, Rejection> {
+async fn get_query<T: IpfsTypes>(
+    mut ipfs: Ipfs<T>,
+    query: GetQuery,
+) -> Result<impl Reply, Rejection> {
     let cid: Cid = query.arg.parse().map_err(StringError::from)?;
     let data = ipfs
         .get_block(&cid)
@@ -22,7 +25,9 @@ async fn get_query<T: IpfsTypes>(mut ipfs: Ipfs<T>, query: GetQuery) -> Result<i
     Ok(response)
 }
 
-pub fn get<T: IpfsTypes>(ipfs: &Ipfs<T>) -> impl Filter<Extract = impl Reply, Error = Rejection> + Clone {
+pub fn get<T: IpfsTypes>(
+    ipfs: &Ipfs<T>,
+) -> impl Filter<Extract = impl Reply, Error = Rejection> + Clone {
     path!("block" / "get")
         .and(with_ipfs(ipfs))
         .and(query::<GetQuery>())
@@ -96,7 +101,9 @@ async fn put_query<T: IpfsTypes>(
     Ok(reply::json(&response))
 }
 
-pub fn put<T: IpfsTypes>(ipfs: &Ipfs<T>) -> impl Filter<Extract = impl Reply, Error = Rejection> + Clone {
+pub fn put<T: IpfsTypes>(
+    ipfs: &Ipfs<T>,
+) -> impl Filter<Extract = impl Reply, Error = Rejection> + Clone {
     path!("block" / "put")
         .and(with_ipfs(ipfs))
         .and(query::<PutQuery>())
@@ -118,14 +125,18 @@ async fn rm_query<T: IpfsTypes>(_ipfs: Ipfs<T>, _query: RmQuery) -> Result<impl 
     Ok(reply::json(&response))
 }
 
-pub fn rm<T: IpfsTypes>(ipfs: &Ipfs<T>) -> impl Filter<Extract = impl Reply, Error = Rejection> + Clone {
+pub fn rm<T: IpfsTypes>(
+    ipfs: &Ipfs<T>,
+) -> impl Filter<Extract = impl Reply, Error = Rejection> + Clone {
     path!("block" / "rm")
         .and(with_ipfs(ipfs))
         .and(query::<RmQuery>())
         .and_then(rm_query)
 }
 
-pub fn stat<T: IpfsTypes>(ipfs: &Ipfs<T>) -> impl Filter<Extract = impl Reply, Error = Rejection> + Clone {
+pub fn stat<T: IpfsTypes>(
+    ipfs: &Ipfs<T>,
+) -> impl Filter<Extract = impl Reply, Error = Rejection> + Clone {
     path!("block" / "stat")
         .and(with_ipfs(ipfs))
         .and(query::<RmQuery>())

--- a/http/src/v0/support.rs
+++ b/http/src/v0/support.rs
@@ -69,13 +69,22 @@ impl warp::reject::Reject for NonUtf8Topic {}
 pub(crate) struct RequiredArgumentMissing(pub(crate) &'static [u8]);
 impl warp::reject::Reject for RequiredArgumentMissing {}
 
+#[derive(Debug)]
+pub(crate) struct InvalidMultipartFormData;
+impl warp::reject::Reject for InvalidMultipartFormData {}
+impl From<InvalidMultipartFormData> for warp::Rejection {
+    fn from(err: InvalidMultipartFormData) -> warp::Rejection {
+        warp::reject::custom(err)
+    }
+}
+
 /// Marker for `warp` specific rejections when something is unimplemented
 #[derive(Debug)]
 pub(crate) struct NotImplemented;
 impl warp::reject::Reject for NotImplemented {}
-impl Into<warp::reject::Rejection> for NotImplemented {
-    fn into(self) -> warp::reject::Rejection {
-        warp::reject::custom(self)
+impl From<NotImplemented> for warp::Rejection {
+    fn from(err: NotImplemented) -> warp::Rejection {
+        warp::reject::custom(err)
     }
 }
 
@@ -83,18 +92,27 @@ impl Into<warp::reject::Rejection> for NotImplemented {
 #[derive(Debug)]
 pub(crate) struct InvalidPeerId;
 impl warp::reject::Reject for InvalidPeerId {}
+impl From<InvalidPeerId> for warp::Rejection {
+    fn from(err: InvalidPeerId) -> warp::Rejection {
+        warp::reject::custom(err)
+    }
+}
 
 /// Default placeholder for ipfs::Error but once we get more typed errors we could start making
 /// them more readable, if needed.
+// TODO: needs to be considered if this is even needed..
 #[derive(Debug)]
 pub(crate) struct StringError(Cow<'static, str>);
 impl warp::reject::Reject for StringError {}
+impl From<StringError> for warp::Rejection {
+    fn from(err: StringError) -> warp::Rejection {
+        warp::reject::custom(err)
+    }
+}
 
-// FIXME: it's a bit questionable to keep this but in the beginning it might help us glide in the
-// right direction.
-impl From<ipfs::Error> for StringError {
-    fn from(e: ipfs::Error) -> Self {
-        Self(format!("{}", e).into())
+impl<D: std::fmt::Display> From<D> for StringError {
+    fn from(d: D) -> Self {
+        Self(format!("{}", d).into())
     }
 }
 

--- a/src/dag.rs
+++ b/src/dag.rs
@@ -27,7 +27,7 @@ impl<Types: RepoTypes> IpldDag<Types> {
         };
         let cid = Cid::new(version, codec, hash)?;
         let block = Block::new(bytes, cid);
-        let cid = self.repo.put_block(block).await?;
+        let (cid, _) = self.repo.put_block(block).await?;
         Ok(cid)
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -491,7 +491,10 @@ impl<Types: IpfsTypes> Ipfs<Types> {
         Ok(rx.await?)
     }
 
-    pub async fn bitswap_wantlist(&self, peer: Option<PeerId>) -> Result<Vec<(Cid, bitswap::Priority)>, Error> {
+    pub async fn bitswap_wantlist(
+        &self,
+        peer: Option<PeerId>,
+    ) -> Result<Vec<(Cid, bitswap::Priority)>, Error> {
         let (tx, rx) = oneshot_channel();
 
         self.to_task
@@ -636,7 +639,10 @@ impl<Types: SwarmTypes> Future for IpfsFuture<Types> {
                     }
                     IpfsEvent::WantList(peer, ret) => {
                         let list = if let Some(peer) = peer {
-                            self.swarm.bitswap().peer_wantlist(&peer).unwrap_or_default()
+                            self.swarm
+                                .bitswap()
+                                .peer_wantlist(&peer)
+                                .unwrap_or_default()
                         } else {
                             self.swarm.bitswap().local_wantlist()
                         };
@@ -683,7 +689,9 @@ pub struct BitswapStats {
 }
 
 impl From<(bitswap::Stats, Vec<PeerId>, Vec<(Cid, bitswap::Priority)>)> for BitswapStats {
-    fn from((stats, peers, wantlist): (bitswap::Stats, Vec<PeerId>, Vec<(Cid, bitswap::Priority)>)) -> Self {
+    fn from(
+        (stats, peers, wantlist): (bitswap::Stats, Vec<PeerId>, Vec<(Cid, bitswap::Priority)>),
+    ) -> Self {
         BitswapStats {
             blocks_sent: stats.sent_blocks,
             data_sent: stats.sent_data,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -632,6 +632,18 @@ impl<Types: SwarmTypes> Future for IpfsFuture<Types> {
     }
 }
 
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct BitswapStats {
+    pub blocks_sent: u64,
+    pub data_sent: u64,
+    pub blocks_received: u64,
+    pub data_received: u64,
+    pub dup_blks_received: u64,
+    pub dup_data_received: u64,
+    pub peers: Vec<PeerId>,
+    pub wantlist: Vec<(Cid, bitswap::Priority)>,
+}
+
 #[doc(hidden)]
 pub use node::Node;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -740,6 +740,12 @@ mod node {
             &self.ipfs
         }
     }
+
+    impl std::ops::DerefMut for Node {
+        fn deref_mut(&mut self) -> &mut <Self as std::ops::Deref>::Target {
+            &mut self.ipfs
+        }
+    }
 }
 
 #[cfg(test)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -615,24 +615,24 @@ impl<Types: SwarmTypes> Future for IpfsFuture<Types> {
                         let _ = ret.send(addresses);
                     }
                     IpfsEvent::PubsubSubscribe(topic, ret) => {
-                        let _ = ret.send(self.swarm.as_mut().subscribe(topic));
+                        let _ = ret.send(self.swarm.pubsub().subscribe(topic));
                     }
                     IpfsEvent::PubsubUnsubscribe(topic, ret) => {
-                        let _ = ret.send(self.swarm.as_mut().unsubscribe(topic));
+                        let _ = ret.send(self.swarm.pubsub().unsubscribe(topic));
                     }
                     IpfsEvent::PubsubPublish(topic, data, ret) => {
-                        self.swarm.as_mut().publish(topic, data);
+                        self.swarm.pubsub().publish(topic, data);
                         let _ = ret.send(());
                     }
                     IpfsEvent::PubsubPeers(Some(topic), ret) => {
                         let topic = libp2p::floodsub::Topic::new(topic);
-                        let _ = ret.send(self.swarm.as_mut().subscribed_peers(&topic));
+                        let _ = ret.send(self.swarm.pubsub().subscribed_peers(&topic));
                     }
                     IpfsEvent::PubsubPeers(None, ret) => {
-                        let _ = ret.send(self.swarm.as_mut().known_peers());
+                        let _ = ret.send(self.swarm.pubsub().known_peers());
                     }
                     IpfsEvent::PubsubSubscribed(ret) => {
-                        let _ = ret.send(self.swarm.as_mut().subscribed_topics());
+                        let _ = ret.send(self.swarm.pubsub().subscribed_topics());
                     }
                     IpfsEvent::WantList(peer, ret) => {
                         todo!()

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -635,7 +635,12 @@ impl<Types: SwarmTypes> Future for IpfsFuture<Types> {
                         let _ = ret.send(self.swarm.pubsub().subscribed_topics());
                     }
                     IpfsEvent::WantList(peer, ret) => {
-                        todo!()
+                        let list = if let Some(peer) = peer {
+                            self.swarm.bitswap().peer_wantlist(&peer).unwrap_or_default()
+                        } else {
+                            self.swarm.bitswap().local_wantlist()
+                        };
+                        let _ = ret.send(list);
                     }
                     IpfsEvent::BitswapStats(ret) => {
                         todo!()

--- a/src/p2p/behaviour.rs
+++ b/src/p2p/behaviour.rs
@@ -236,6 +236,10 @@ impl<TSwarmTypes: SwarmTypes> Behaviour<TSwarmTypes> {
     pub fn pubsub(&mut self) -> &mut Pubsub {
         &mut self.pubsub
     }
+
+    pub fn bitswap(&mut self) -> &mut Bitswap<TSwarmTypes::TStrategy> {
+        &mut self.bitswap
+    }
 }
 
 /// Create a IPFS behaviour with the IPFS bootstrap nodes.

--- a/src/p2p/behaviour.rs
+++ b/src/p2p/behaviour.rs
@@ -232,10 +232,8 @@ impl<TSwarmTypes: SwarmTypes> Behaviour<TSwarmTypes> {
         //let hash = Multihash::from_bytes(cid.to_bytes()).unwrap();
         //self.kademlia.remove_providing(&hash);
     }
-}
 
-impl<T: SwarmTypes> std::convert::AsMut<Pubsub> for Behaviour<T> {
-    fn as_mut(&mut self) -> &mut Pubsub {
+    pub fn pubsub(&mut self) -> &mut Pubsub {
         &mut self.pubsub
     }
 }

--- a/src/repo/fs.rs
+++ b/src/repo/fs.rs
@@ -1,6 +1,6 @@
 //! Persistent fs backed repo
 use crate::error::Error;
-use crate::repo::{BlockStore, BlockPut};
+use crate::repo::{BlockPut, BlockStore};
 #[cfg(feature = "rocksdb")]
 use crate::repo::{Column, DataStore};
 use async_std::fs;

--- a/src/repo/mem.rs
+++ b/src/repo/mem.rs
@@ -1,6 +1,6 @@
 //! Volatile memory backed repo
 use crate::error::Error;
-use crate::repo::{BlockStore, BlockPut, Column, DataStore};
+use crate::repo::{BlockPut, BlockStore, Column, DataStore};
 use async_std::path::PathBuf;
 use async_std::sync::{Arc, Mutex};
 use async_trait::async_trait;

--- a/src/repo/mod.rs
+++ b/src/repo/mod.rs
@@ -50,7 +50,7 @@ pub enum BlockPut {
     /// A new block was written
     NewBlock,
     /// The block existed already
-    Existed
+    Existed,
 }
 
 /// This API is being discussed and evolved, which will likely lead to breakage.

--- a/tests/exchange_block.rs
+++ b/tests/exchange_block.rs
@@ -2,7 +2,6 @@ use ipfs::{Block, Node};
 use libipld::cid::{Cid, Codec};
 use multihash::Sha2_256;
 
-/// Discovers a peer via mdns and exchanges a block through bitswap.
 #[async_std::test]
 async fn exchange_block() {
     env_logger::init();

--- a/tests/exchange_block.rs
+++ b/tests/exchange_block.rs
@@ -1,0 +1,28 @@
+use ipfs::{Block, Node};
+use libipld::cid::{Cid, Codec};
+use multihash::Sha2_256;
+
+/// Discovers a peer via mdns and exchanges a block through bitswap.
+#[async_std::test]
+async fn exchange_block() {
+    env_logger::init();
+    let mdns = false;
+
+    let data = b"hello block\n".to_vec().into_boxed_slice();
+    let cid = Cid::new_v1(Codec::Raw, Sha2_256::digest(&data));
+
+    let mut a = Node::new(mdns).await;
+    let mut b = Node::new(mdns).await;
+
+    let (_, mut addrs) = b.identity().await.unwrap();
+
+    a.connect(addrs.pop().expect("b must have address to connect to"))
+        .await
+        .unwrap();
+
+    a.put_block(Block { cid: cid.clone(), data: data.clone() }).await.unwrap();
+
+    let Block { data: data2, .. } = b.get_block(&cid).await.unwrap();
+
+    assert_eq!(data, data2);
+}

--- a/tests/exchange_block.rs
+++ b/tests/exchange_block.rs
@@ -20,7 +20,12 @@ async fn exchange_block() {
         .await
         .unwrap();
 
-    a.put_block(Block { cid: cid.clone(), data: data.clone() }).await.unwrap();
+    a.put_block(Block {
+        cid: cid.clone(),
+        data: data.clone(),
+    })
+    .await
+    .unwrap();
 
     let Block { data: data2, .. } = b.get_block(&cid).await.unwrap();
 


### PR DESCRIPTION
Depends on #130 and takes the functionality developed on #126 (`/block` and `/bitswap`) but without the major refactoring. In the end I was surprised that the `tests/block_exchange.rs` worked. I tried to add `Co-authored-by:` headers to the commits which took the code @dvc94ch had published.

I had missed the changes made to bitswap on #99 which I merged in hurry so it took some fixing. I think the idea of removing BitswapStore altogether and replacing it and all the spawns by BehaviourEvent is the right way to go. I think it'll be an easier refactoring on top of this now that the `exchange_block` test should be working.

New thing here to allow accounting for duplicate blocks is the `put_block(...) -> Result<(Cid, BlockPut), _>` where `BlockPut` is a simple enum representing whether or not the block existed already. I think there are alternatives to this but can't see any other route than it being encoded to the signature of `put_block(....)` method.

Pretty much all of the refactorings you've presented seem ok but I'd prefer if you'd provide them as "mostly independent" so that we can review and learn from them better.