### PR TITLE
Fix more flaky tests

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -684,9 +684,11 @@ mod tests {
     use libipld::ipld;
     use multihash::Sha2_256;
 
+    const MDNS: bool = false;
+
     #[async_std::test]
     async fn test_put_and_get_block() {
-        let options = IpfsOptions::<TestTypes>::default();
+        let options = IpfsOptions::inmemory_with_generated_keys(MDNS);
         let data = b"hello block\n".to_vec().into_boxed_slice();
         let cid = Cid::new_v1(Codec::Raw, Sha2_256::digest(&data));
         let block = Block::new(data, cid);
@@ -703,7 +705,7 @@ mod tests {
 
     #[async_std::test]
     async fn test_put_and_get_dag() {
-        let options = IpfsOptions::<TestTypes>::default();
+        let options = IpfsOptions::inmemory_with_generated_keys(MDNS);
 
         let (ipfs, fut) = UninitializedIpfs::new(options).await.start().await.unwrap();
         task::spawn(fut);
@@ -718,7 +720,7 @@ mod tests {
 
     #[async_std::test]
     async fn test_pin_and_unpin() {
-        let options = IpfsOptions::<TestTypes>::default();
+        let options = IpfsOptions::inmemory_with_generated_keys(MDNS);
 
         let (ipfs, fut) = UninitializedIpfs::new(options).await.start().await.unwrap();
         task::spawn(fut);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -38,7 +38,6 @@ pub mod repo;
 mod subscription;
 pub mod unixfs;
 
-use self::config::ConfigFile;
 use self::dag::IpldDag;
 pub use self::error::Error;
 use self::ipns::Ipns;
@@ -160,7 +159,25 @@ impl<Types: IpfsTypes> IpfsOptions<Types> {
 
 impl<T: IpfsTypes> Default for IpfsOptions<T> {
     /// Create `IpfsOptions` from environment.
+    ///
+    /// # Panics
+    ///
+    /// Can panic if two threads call this method at the same time due to race condition on
+    /// creating a configuration file under `IPFS_PATH` and other thread failing to read the just
+    /// created empty file. Because of this, the implementation has been disabled in tests.
     fn default() -> Self {
+        use self::config::ConfigFile;
+
+        if cfg!(test) {
+            // making this implementation conditional on `not(test)` results in multiple dead_code
+            // lints on config.rs but for rustc 1.42.0 at least having this `cfg!(test)` branch
+            // does not result in the same.
+            panic!(
+                "This implementation must not be invoked when testing as it cannot be safely
+                used from multiple threads"
+            );
+        }
+
         let ipfs_path = if let Ok(path) = std::env::var("IPFS_PATH") {
             PathBuf::from(path)
         } else {
@@ -734,5 +751,11 @@ mod tests {
         assert!(!ipfs.is_pinned(&cid).await.unwrap());
 
         ipfs.exit_daemon().await;
+    }
+
+    #[test]
+    #[should_panic]
+    fn default_ipfs_options_disabled_when_testing() {
+        IpfsOptions::<TestTypes>::default();
     }
 }


### PR DESCRIPTION
Fixes the three flaky tests and tries to make sure no new similarly flaky tests can be introduced, document the thread unsafety.

I didn't go and start using a mutex or anything like that because the use of filesystem is always prone to races.