### PR TITLE
Add refs endpoint

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -696,10 +696,10 @@ dependencies = [
 [[package]]
 name = "dag-cbor"
 version = "0.1.0"
-source = "git+https://github.com/ipfs-rust/rust-ipld#f6bb3b2e993afc7b4562a9601007e19c5f53d570"
+source = "git+https://github.com/ipfs-rust/rust-ipld?rev=b2286c53c13f3eeec2a3766387f2926838e8e4c9#b2286c53c13f3eeec2a3766387f2926838e8e4c9"
 dependencies = [
  "byteorder 1.3.4",
- "libipld-base 0.1.0 (git+https://github.com/ipfs-rust/rust-ipld)",
+ "libipld-base 0.1.0 (git+https://github.com/ipfs-rust/rust-ipld?rev=b2286c53c13f3eeec2a3766387f2926838e8e4c9)",
  "thiserror",
 ]
 
@@ -717,7 +717,7 @@ dependencies = [
 [[package]]
 name = "dag-cbor-derive"
 version = "0.1.0"
-source = "git+https://github.com/ipfs-rust/rust-ipld#f6bb3b2e993afc7b4562a9601007e19c5f53d570"
+source = "git+https://github.com/ipfs-rust/rust-ipld?rev=b2286c53c13f3eeec2a3766387f2926838e8e4c9#b2286c53c13f3eeec2a3766387f2926838e8e4c9"
 dependencies = [
  "proc-macro2 1.0.10",
  "quote 1.0.3",
@@ -740,10 +740,10 @@ dependencies = [
 [[package]]
 name = "dag-json"
 version = "0.1.0"
-source = "git+https://github.com/ipfs-rust/rust-ipld#f6bb3b2e993afc7b4562a9601007e19c5f53d570"
+source = "git+https://github.com/ipfs-rust/rust-ipld?rev=b2286c53c13f3eeec2a3766387f2926838e8e4c9#b2286c53c13f3eeec2a3766387f2926838e8e4c9"
 dependencies = [
  "base64 0.12.0",
- "libipld-base 0.1.0 (git+https://github.com/ipfs-rust/rust-ipld)",
+ "libipld-base 0.1.0 (git+https://github.com/ipfs-rust/rust-ipld?rev=b2286c53c13f3eeec2a3766387f2926838e8e4c9)",
  "serde",
  "serde_json",
 ]
@@ -751,9 +751,9 @@ dependencies = [
 [[package]]
 name = "dag-pb"
 version = "0.1.0"
-source = "git+https://github.com/ipfs-rust/rust-ipld#f6bb3b2e993afc7b4562a9601007e19c5f53d570"
+source = "git+https://github.com/ipfs-rust/rust-ipld?rev=b2286c53c13f3eeec2a3766387f2926838e8e4c9#b2286c53c13f3eeec2a3766387f2926838e8e4c9"
 dependencies = [
- "libipld-base 0.1.0 (git+https://github.com/ipfs-rust/rust-ipld)",
+ "libipld-base 0.1.0 (git+https://github.com/ipfs-rust/rust-ipld?rev=b2286c53c13f3eeec2a3766387f2926838e8e4c9)",
  "prost",
  "prost-build",
  "thiserror",
@@ -1366,7 +1366,7 @@ dependencies = [
  "domain",
  "env_logger",
  "futures 0.3.4",
- "libipld 0.1.0 (git+https://github.com/ipfs-rust/rust-ipld)",
+ "libipld 0.1.0 (git+https://github.com/ipfs-rust/rust-ipld?rev=b2286c53c13f3eeec2a3766387f2926838e8e4c9)",
  "libp2p",
  "log 0.4.8",
  "multibase",
@@ -1389,7 +1389,7 @@ dependencies = [
  "env_logger",
  "futures 0.3.4",
  "ipfs",
- "libipld 0.1.0 (git+https://github.com/ipfs-rust/rust-ipld)",
+ "libipld 0.1.0 (git+https://github.com/ipfs-rust/rust-ipld?rev=b2286c53c13f3eeec2a3766387f2926838e8e4c9)",
  "multihash",
 ]
 
@@ -1403,7 +1403,7 @@ dependencies = [
  "futures 0.3.4",
  "hex",
  "ipfs",
- "libipld 0.1.0 (git+https://github.com/ipfs-rust/rust-ipld)",
+ "libipld 0.1.0 (git+https://github.com/ipfs-rust/rust-ipld?rev=b2286c53c13f3eeec2a3766387f2926838e8e4c9)",
  "log 0.4.8",
  "multibase",
  "multihash",
@@ -1507,19 +1507,19 @@ checksum = "eb147597cdf94ed43ab7a9038716637d2d1bf2bc571da995d0028dec06bd3018"
 [[package]]
 name = "libipld"
 version = "0.1.0"
-source = "git+https://github.com/ipfs-rust/rust-ipld#f6bb3b2e993afc7b4562a9601007e19c5f53d570"
+source = "git+https://github.com/ipfs-rust/rust-ipld?rev=b2286c53c13f3eeec2a3766387f2926838e8e4c9#b2286c53c13f3eeec2a3766387f2926838e8e4c9"
 dependencies = [
  "async-std",
  "async-trait",
  "byteorder 1.3.4",
  "cid",
- "dag-cbor 0.1.0 (git+https://github.com/ipfs-rust/rust-ipld)",
- "dag-cbor-derive 0.1.0 (git+https://github.com/ipfs-rust/rust-ipld)",
+ "dag-cbor 0.1.0 (git+https://github.com/ipfs-rust/rust-ipld?rev=b2286c53c13f3eeec2a3766387f2926838e8e4c9)",
+ "dag-cbor-derive 0.1.0 (git+https://github.com/ipfs-rust/rust-ipld?rev=b2286c53c13f3eeec2a3766387f2926838e8e4c9)",
  "dag-json",
  "dag-pb",
  "futures 0.3.4",
- "libipld-base 0.1.0 (git+https://github.com/ipfs-rust/rust-ipld)",
- "libipld-macro 0.1.0 (git+https://github.com/ipfs-rust/rust-ipld)",
+ "libipld-base 0.1.0 (git+https://github.com/ipfs-rust/rust-ipld?rev=b2286c53c13f3eeec2a3766387f2926838e8e4c9)",
+ "libipld-macro 0.1.0 (git+https://github.com/ipfs-rust/rust-ipld?rev=b2286c53c13f3eeec2a3766387f2926838e8e4c9)",
  "multibase",
  "multihash",
  "thiserror",
@@ -1548,7 +1548,7 @@ dependencies = [
 [[package]]
 name = "libipld-base"
 version = "0.1.0"
-source = "git+https://github.com/ipfs-rust/rust-ipld#f6bb3b2e993afc7b4562a9601007e19c5f53d570"
+source = "git+https://github.com/ipfs-rust/rust-ipld?rev=b2286c53c13f3eeec2a3766387f2926838e8e4c9#b2286c53c13f3eeec2a3766387f2926838e8e4c9"
 dependencies = [
  "cid",
  "multibase",
@@ -1570,9 +1570,9 @@ dependencies = [
 [[package]]
 name = "libipld-macro"
 version = "0.1.0"
-source = "git+https://github.com/ipfs-rust/rust-ipld#f6bb3b2e993afc7b4562a9601007e19c5f53d570"
+source = "git+https://github.com/ipfs-rust/rust-ipld?rev=b2286c53c13f3eeec2a3766387f2926838e8e4c9#b2286c53c13f3eeec2a3766387f2926838e8e4c9"
 dependencies = [
- "libipld-base 0.1.0 (git+https://github.com/ipfs-rust/rust-ipld)",
+ "libipld-base 0.1.0 (git+https://github.com/ipfs-rust/rust-ipld?rev=b2286c53c13f3eeec2a3766387f2926838e8e4c9)",
  "multihash",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1417,6 +1417,7 @@ dependencies = [
  "structopt",
  "thiserror",
  "tokio 0.2.16",
+ "url",
  "vergen",
  "warp",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1409,6 +1409,7 @@ dependencies = [
  "multihash",
  "openssl",
  "percent-encoding",
+ "pin-project",
  "prost",
  "prost-build",
  "serde",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -156,6 +156,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "async-stream"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22068c0c19514942eefcfd4daf8976ef1aad84e61539f95cd200c35202f80af5"
+dependencies = [
+ "async-stream-impl",
+ "futures-core",
+]
+
+[[package]]
+name = "async-stream-impl"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "25f9db3b38af870bf7e5cc649167533b493928e50744e2c30ae350230b414670"
+dependencies = [
+ "proc-macro2 1.0.10",
+ "quote 1.0.3",
+ "syn 1.0.17",
+]
+
+[[package]]
 name = "async-task"
 version = "1.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1208,6 +1229,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "hex"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "644f9158b2f133fd50f5fb3242878846d9eb792e445c893805ff0e3824006e35"
+
+[[package]]
 name = "hmac"
 version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1370,9 +1397,11 @@ dependencies = [
 name = "ipfs-http"
 version = "0.1.0"
 dependencies = [
+ "async-stream",
  "base64 0.12.0",
  "env_logger",
  "futures 0.3.4",
+ "hex",
  "ipfs",
  "libipld 0.1.0 (git+https://github.com/ipfs-rust/rust-ipld)",
  "log 0.4.8",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ byteorder = "1.3.4"
 dirs = "2.0.2"
 domain = { git = "https://github.com/nlnetlabs/domain", rev="084964", features = ["resolv"] }
 futures = { version = "0.3.4", features = ["compat", "io-compat"] }
-libipld = { git = "https://github.com/ipfs-rust/rust-ipld", features = ["dag-pb"] }
+libipld = { git = "https://github.com/ipfs-rust/rust-ipld", rev = "b2286c53c13f3eeec2a3766387f2926838e8e4c9", features = ["dag-pb", "dag-json"] }
 libp2p = "0.16.2"
 log = "0.4.8"
 multibase = "0.8.0"

--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -10,5 +10,5 @@ async-std = "1.5.0"
 env_logger = "0.7.1"
 futures = "0.3.4"
 ipfs = { path = ".." }
-libipld = { git = "https://github.com/ipfs-rust/rust-ipld", features = ["dag-pb"] }
+libipld = { git = "https://github.com/ipfs-rust/rust-ipld", rev = "b2286c53c13f3eeec2a3766387f2926838e8e4c9", features = ["dag-pb", "dag-json"] }
 multihash = "0.10.1"

--- a/http/Cargo.toml
+++ b/http/Cargo.toml
@@ -30,6 +30,7 @@ tokio = { version = "0.2.16", features = ["full"] }
 warp = "0.2.2"
 async-stream = "0.2.1"
 pin-project = "0.4.8"
+url = "2.1.1"
 
 [dev-dependencies]
 hex = "0.4.2"

--- a/http/Cargo.toml
+++ b/http/Cargo.toml
@@ -14,7 +14,7 @@ base64 = "0.12.0"
 env_logger = "0.7.1"
 futures = "0.3.4"
 ipfs = { path = "../" }
-libipld = { git = "https://github.com/ipfs-rust/rust-ipld", features = ["dag-pb", "dag-json"] }
+libipld = { git = "https://github.com/ipfs-rust/rust-ipld", rev = "b2286c53c13f3eeec2a3766387f2926838e8e4c9", features = ["dag-pb", "dag-json"] }
 log = "0.4.8"
 multibase = "0.8.0"
 multihash = "0.10.1"

--- a/http/Cargo.toml
+++ b/http/Cargo.toml
@@ -29,6 +29,7 @@ thiserror = "1.0.14"
 tokio = { version = "0.2.16", features = ["full"] }
 warp = "0.2.2"
 async-stream = "0.2.1"
+pin-project = "0.4.8"
 
 [dev-dependencies]
 hex = "0.4.2"

--- a/http/Cargo.toml
+++ b/http/Cargo.toml
@@ -28,3 +28,7 @@ structopt = "0.3.12"
 thiserror = "1.0.14"
 tokio = { version = "0.2.16", features = ["full"] }
 warp = "0.2.2"
+async-stream = "0.2.1"
+
+[dev-dependencies]
+hex = "0.4.2"

--- a/http/src/lib.rs
+++ b/http/src/lib.rs
@@ -1,4 +1,4 @@
-#![recursion_limit = "256"]
+#![recursion_limit = "512"]
 
 pub mod v0;
 

--- a/http/src/lib.rs
+++ b/http/src/lib.rs
@@ -1,3 +1,5 @@
+#![recursion_limit = "256"]
+
 pub mod v0;
 
 pub mod config;

--- a/http/src/main.rs
+++ b/http/src/main.rs
@@ -182,7 +182,7 @@ fn serve<Types: IpfsTypes>(
     let (shutdown_tx, mut shutdown_rx) = tokio::sync::mpsc::channel::<()>(1);
 
     let routes = v0::routes(ipfs, shutdown_tx);
-    let routes = routes.with(warp::log("rust-ipfs-http-v0"));
+    let routes = routes.with(warp::log(env!("CARGO_PKG_NAME")));
 
     let ipfs = ipfs.clone();
 

--- a/http/src/v0.rs
+++ b/http/src/v0.rs
@@ -55,7 +55,7 @@ where
             .or(warp::path!("ping" / ..).and_then(not_implemented))
             .or(pubsub::routes(ipfs))
             .or(refs::local(ipfs))
-            // .or(warp::path!("refs").and_then(refs::of_path))
+            .or(refs::refs(ipfs))
             .or(warp::path!("repo" / ..).and_then(not_implemented))
             .or(warp::path!("stats" / ..).and_then(not_implemented))
             .or(swarm::connect(ipfs))

--- a/http/src/v0/refs.rs
+++ b/http/src/v0/refs.rs
@@ -804,14 +804,16 @@ fn iplds_refs<T: IpfsTypes>(
                 _ => {}
             }
 
-            let Block { data, .. } = if let Ok(block) = ipfs.get_block(&cid).await {
-                block
-            } else {
-                // TODO: yield error msg
-                // unsure in which cases this happens, because we'll start to search the content
-                // and stop only when request has been cancelled (FIXME: not yet, because dropping
-                // all subscriptions doesn't "stop the operation.")
-                continue;
+            let data = match ipfs.get_block(&cid).await {
+                Ok(Block { data, .. }) => data,
+                Err(e) => {
+                    log::warn!("failed to load {}, linked from {}: {}", cid, source, e);
+                    // TODO: yield error msg
+                    // unsure in which cases this happens, because we'll start to search the content
+                    // and stop only when request has been cancelled (FIXME: not yet, because dropping
+                    // all subscriptions doesn't "stop the operation.")
+                    continue;
+                }
             };
 
             let mut ipld = match decode_ipld(&cid, &data) {

--- a/http/src/v0/refs.rs
+++ b/http/src/v0/refs.rs
@@ -75,11 +75,6 @@ async fn refs_inner<T: IpfsTypes>(
         res
     });
 
-    //Ok("foo")
-
-    // DUH: async-stream is not Send + Sync + 'static
-    // TODO: check with all of the references removed, for example get_block, check all parts from
-    // the lib level that the futures are Send + Sync + 'static
     Ok(StreamResponse(Unshared::new(st)))
 }
 
@@ -545,10 +540,6 @@ impl TryFrom<&str> for IpfsPath {
 }
 
 impl IpfsPath {
-    pub fn root(&self) -> Option<&Cid> {
-        self.root.as_ref()
-    }
-
     pub fn take_root(&mut self) -> Option<Cid> {
         self.root.take()
     }

--- a/http/src/v0/refs.rs
+++ b/http/src/v0/refs.rs
@@ -383,7 +383,7 @@ async fn inner_local<T: IpfsTypes>(ipfs: Ipfs<T>) -> Result<impl Reply, Rejectio
 
 #[cfg(test)]
 mod tests {
-    use super::{local, refs_paths, Edge, IpfsPath};
+    use super::{ipld_links, local, refs_paths, Edge, IpfsPath};
     use futures::stream::TryStreamExt;
     use ipfs::{Block, Ipfs};
     use libipld::block::{decode_ipld, validate};
@@ -613,5 +613,29 @@ mod tests {
         }
 
         ipfs
+    }
+
+    #[test]
+    fn dagpb_links() {
+        // this is the same as in v0::refs::path::tests::walk_dagpb_links
+        let payload = hex::decode(
+            "12330a2212206aad27d7e2fc815cd15bf679535062565dc927a831547281\
+            fc0af9e5d7e67c74120b6166726963616e2e747874180812340a221220fd\
+            36ac5279964db0cba8f7fa45f8c4c44ef5e2ff55da85936a378c96c9c632\
+            04120c616d6572696361732e747874180812360a2212207564c20415869d\
+            77a8a40ca68a9158e397dd48bdff1325cdb23c5bcd181acd17120e617573\
+            7472616c69616e2e7478741808",
+        )
+        .unwrap();
+
+        let cid = Cid::try_from("QmbrFTo4s6H23W6wmoZKQC2vSogGeQ4dYiceSqJddzrKVa").unwrap();
+
+        let decoded = decode_ipld(&cid, &payload).unwrap();
+
+        let links = ipld_links(&cid, decoded)
+            .map(|(name, _)| name.unwrap())
+            .collect::<Vec<_>>();
+
+        assert_eq!(links, ["african.txt", "americas.txt", "australian.txt",]);
     }
 }

--- a/http/src/v0/refs.rs
+++ b/http/src/v0/refs.rs
@@ -478,6 +478,7 @@ impl fmt::Display for PathError {
 impl std::error::Error for PathError {}
 
 /// Following https://github.com/ipfs/go-path/
+#[derive(Debug)]
 struct IpfsPath {
     /// Option to support moving the cid
     root: Option<Cid>,
@@ -640,7 +641,34 @@ impl IpfsPath {
 
         Ok(WalkSuccess::AtDestination(ipld))
     }
+
+    fn debug<'a>(&'a self, current: &'a Cid) -> DebuggableIpfsPath<'a> {
+        DebuggableIpfsPath {
+            current,
+            segments: self.path.as_slice(),
+        }
+    }
 }
+
+struct DebuggableIpfsPath<'a> {
+    current: &'a Cid,
+    segments: &'a [String],
+}
+
+impl<'a> fmt::Debug for DebuggableIpfsPath<'a> {
+    fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
+        write!(fmt, "{}", self.current)?;
+        if !self.segments.is_empty() {
+            write!(fmt, "/...")?;
+        }
+
+        for seg in self.segments {
+            write!(fmt, "/{}", seg)?;
+        }
+        Ok(())
+    }
+}
+
 
 pub enum WalkSuccess {
     /// IpfsPath was already empty, or became empty during previous walk

--- a/http/src/v0/refs.rs
+++ b/http/src/v0/refs.rs
@@ -819,6 +819,7 @@ fn iplds_refs<T: IpfsTypes>(
             let mut ipld = match decode_ipld(&cid, &data) {
                 Ok(ipld) => ipld,
                 Err(e) => {
+                    log::warn!("failed to parse {}, linked from {}: {}", cid, source, e);
                     // TODO: yield error msg
                     // go-ipfs on raw Qm hash:
                     // > failed to decode Protocol Buffers: incorrectly formatted merkledag node: unmarshal failed. proto: illegal wireType 6
@@ -827,9 +828,6 @@ fn iplds_refs<T: IpfsTypes>(
             };
 
             for (link_name, next_cid) in ipld_links(ipld) {
-                if cid.codec() == CidCodec::DagProtobuf {
-                    log::trace!("dag-pb link: {} -> {}", cid, next_cid);
-                }
                 work.push_back((depth + 1, next_cid, cid.clone(), link_name));
             }
 

--- a/http/src/v0/refs.rs
+++ b/http/src/v0/refs.rs
@@ -679,6 +679,8 @@ pub enum WalkSuccess {
     Link(String, Cid),
 }
 
+// FIXME: this probably needs to result in http 40x error? Currently converted to a stringerror
+// which is 500.
 #[derive(Debug)]
 pub enum WalkFailed {
     /// Map key was not found

--- a/http/src/v0/refs.rs
+++ b/http/src/v0/refs.rs
@@ -823,6 +823,7 @@ fn iplds_refs<T: IpfsTypes>(
                     // TODO: yield error msg
                     // go-ipfs on raw Qm hash:
                     // > failed to decode Protocol Buffers: incorrectly formatted merkledag node: unmarshal failed. proto: illegal wireType 6
+                    yield Err(e.to_string());
                     continue;
                 }
             };

--- a/http/src/v0/refs.rs
+++ b/http/src/v0/refs.rs
@@ -214,18 +214,45 @@ impl RefsOptions {
 
         if self.edges {
             Ok(EdgeFormatter::Arrow)
-        } else if self.format.is_some() {
-            Err(StringError::new("format not yet implemented".into()))
+        } else if let Some(formatstr) = self.format.as_deref() {
+            let parts = parse_format(formatstr).map_err(StringError::from)?;
+            Ok(EdgeFormatter::FormatString(parts))
         } else {
             Ok(EdgeFormatter::Destination)
         }
     }
 }
 
+
 #[derive(Debug)]
 enum EdgeFormatter {
     Destination,
     Arrow,
+    FormatString(Vec<FormattedPart>)
+}
+
+/// Different parts of the format string
+#[derive(Debug, PartialEq, Eq)]
+enum FormattedPart {
+    Static(String),
+    Source,
+    Destination,
+    LinkName
+}
+
+impl FormattedPart {
+    fn format(&self, out: &mut String, src: &Cid, dst: &Cid, linkname: Option<&str>) {
+        use FormattedPart::*;
+        use fmt::Write;
+        match *self {
+            Static(ref s) => out.push_str(s),
+            Source => write!(out, "{}", src).expect("String writing shouldn't fail"),
+            Destination => write!(out, "{}", dst).expect("String writing shouldn't fail"),
+            LinkName => if let Some(s) = linkname {
+                out.push_str(s)
+            },
+        }
+    }
 }
 
 impl EdgeFormatter {
@@ -233,7 +260,93 @@ impl EdgeFormatter {
         match *self {
             EdgeFormatter::Destination => dst.to_string(),
             EdgeFormatter::Arrow => format!("{} -> {}", src, dst),
+            EdgeFormatter::FormatString(ref parts) => {
+                let mut out = String::new();
+                for part in parts {
+                    part.format(&mut out, &src, &dst, None);
+                }
+                out.shrink_to_fit();
+                out
+            },
         }
+    }
+}
+
+#[derive(Debug)]
+enum FormatError<'a> {
+    UnsupportedTag(&'a str),
+    UnterminatedTag(usize)
+}
+
+impl<'a> fmt::Display for FormatError<'a> {
+    fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
+        use FormatError::*;
+        match *self {
+            UnsupportedTag(tag) => write!(fmt, "unsupported tag: {:?}", tag),
+            UnterminatedTag(index) => write!(fmt, "unterminated tag at index: {}", index),
+        }
+    }
+}
+
+impl<'a> std::error::Error for FormatError<'a> {}
+
+fn parse_format(s: &str) -> Result<Vec<FormattedPart>, FormatError> {
+    use std::mem;
+
+    let mut buffer = String::new();
+    let mut ret = Vec::new();
+    let mut chars = s.char_indices();
+
+    loop {
+        match chars.next() {
+            Some((index, '<')) => {
+                if !buffer.is_empty() {
+                    ret.push(FormattedPart::Static(mem::take(&mut buffer)));
+                }
+
+                let remaining = chars.as_str();
+                let end = remaining.find('>').ok_or_else(|| FormatError::UnterminatedTag(index))?;
+
+                // the use of string indices here is ok as the angle brackets are ascii and
+                // cannot be in the middle of multibyte char boundaries
+                let inside = &remaining[0..end];
+
+                // TODO: this might need to be case insensitive
+                let part = match inside {
+                    "src" => FormattedPart::Source,
+                    "dst" => FormattedPart::Destination,
+                    "linkname" => FormattedPart::LinkName,
+                    tag => return Err(FormatError::UnsupportedTag(tag)),
+                };
+
+                ret.push(part);
+
+                // the one here is to ignore the '>', which cannot be a codepoint boundary
+                chars = remaining[end + 1..].char_indices();
+            }
+            Some((_, ch)) => buffer.push(ch),
+            None => {
+                if !buffer.is_empty() {
+                    ret.push(FormattedPart::Static(buffer));
+                }
+                return Ok(ret);
+            }
+        }
+    }
+}
+
+#[test]
+fn parse_good_formats() {
+    use FormattedPart::*;
+
+    let examples = &[
+        ("<linkname>: <src> -> <dst>", vec![LinkName, Static(": ".into()), Source, Static(" -> ".into()), Destination]),
+        ("-<linkname>", vec![Static("-".into()), LinkName]),
+        ("<linkname>-", vec![LinkName, Static("-".into())]),
+    ];
+
+    for (input, expected) in examples {
+        assert_eq!(&parse_format(input).unwrap(), expected);
     }
 }
 

--- a/http/src/v0/refs.rs
+++ b/http/src/v0/refs.rs
@@ -179,8 +179,9 @@ impl IpfsPath {
         }
         while let Some(key) = self.next() {
             ipld = match ipld {
-                Ipld::Link(cid) if key == "." || key == "0" => {
-                    // go-ipfs: not sure why 0 is allowed but lets go with it
+                Ipld::Link(cid) if key == "." => {
+                    // go-ipfs: allows this to be skipped. lets require the dot for now.
+                    // FIXME: this would require the iterator to be peekable in addition.
                     return Ok(WalkSuccess::Link(key, cid));
                 }
                 Ipld::Map(mut m) if m.contains_key(&key) => {

--- a/http/src/v0/refs.rs
+++ b/http/src/v0/refs.rs
@@ -2,6 +2,13 @@ use futures::stream;
 use ipfs::{Ipfs, IpfsTypes};
 use serde::Serialize;
 use warp::hyper::Body;
+use futures::stream::Stream;
+use ipfs::{Block, Error};
+use ipfs::{Ipfs, IpfsTypes};
+use libipld::cid::Cid;
+use serde::Deserialize;
+use std::collections::VecDeque;
+use std::convert::TryFrom;
 use warp::{path, query, Filter, Rejection, Reply};
 use crate::v0::support::{with_ipfs, StringError};
 use serde::Deserialize;
@@ -27,7 +34,7 @@ pub fn refs<T: IpfsTypes>(
 
 async fn refs_inner<T: IpfsTypes>(
     _ipfs: Ipfs<T>,
-    _opts: RefsOptions
+    _opts: RefsOptions,
 ) -> Result<impl Reply, Rejection> {
     Ok("foo")
 }
@@ -56,15 +63,11 @@ struct RefsOptions {
 // Should return all in some order, probably in the order of discovery. Tests sort the values
 // either way. Probably something like struct Edge { source: Cid, destination: Cid }.
 
-use futures::stream::Stream;
-use libipld::cid::Cid;
-use ipfs::{Error, Block};
-use std::convert::TryFrom;
-use std::collections::VecDeque;
-
-fn edges<T: IpfsTypes>(ipfs: Ipfs<T>, start: Cid, max_depth: Option<u64>)
-    -> impl Stream<Item = Result<(Cid, Cid), Error>>
-{
+fn edges<T: IpfsTypes>(
+    ipfs: Ipfs<T>,
+    start: Cid,
+    max_depth: Option<u64>,
+) -> impl Stream<Item = Result<(Cid, Cid), Error>> {
     // FIXME: there should be an optional path
     use async_stream::try_stream;
 
@@ -96,14 +99,14 @@ fn edges<T: IpfsTypes>(ipfs: Ipfs<T>, start: Cid, max_depth: Option<u64>)
     }
 }
 
-use libipld::Ipld;
-
 fn block_links(Block { cid, data }: Block) -> Result<impl Iterator<Item = Cid>, Error> {
+    use libipld::Ipld;
+
     let ipld = libipld::block::decode_ipld(&cid, &data)?;
     // a wrapping iterator without there being a libipld_base::IpldIntoIter might not be doable
     // with safe code
-    Ok(ipld.iter()
-        .inspect(move |ipld| println!("found {} => {:?}", cid, ipld))
+    Ok(ipld
+        .iter()
         .filter_map(|val| match val {
             Ipld::Link(cid) => Some(cid),
             _ => None,
@@ -116,48 +119,77 @@ fn block_links(Block { cid, data }: Block) -> Result<impl Iterator<Item = Cid>, 
 #[tokio::test]
 async fn stack_refs() {
     use futures::stream::TryStreamExt;
+    use libipld::block::{decode_ipld, validate};
 
     let options = ipfs::IpfsOptions::inmemory_with_generated_keys(false);
-    let (ipfs, _) = ipfs::UninitializedIpfs::new(options).await.start().await.unwrap();
+    let (ipfs, _) = ipfs::UninitializedIpfs::new(options)
+        .await
+        .start()
+        .await
+        .unwrap();
 
     let blocks = [
-        ("bafyreidquig3arts3bmee53rutt463hdyu6ff4zeas2etf2h2oh4dfms44", "a263626172d82a58230012200e317512b6f9f86e015a154cb97a9ddcdc7e372cccceb3947921634953c6537463666f6fd82a58250001711220354d455ff3a641b8cac25c38a77e64aa735dc8a48966a60f1a78caa172a4885e"),
-        ("QmPJ4A6Su27ABvvduX78x2qdWMzkdAYxqeH5TVrHeo3xyy", "0a0d08021207626172666f6f0a1807"),
-        ("bafyreibvjvcv745gig4mvqs4hctx4zfkono4rjejm2ta6gtyzkqxfjeily", "a163666f6fd82a582300122031c3d57080d8463a3c63b2923df5a1d40ad7a73eae5a14af584213e5f504ac33"),
-        ("QmRgutAxd8t7oGkSm4wmeuByG6M51wcTso6cubDdQtuEfL", "0a0d08021207666f6f6261720a1807"),
+        (
+            // echo -n '{ "foo": { "/": "bafyreibvjvcv745gig4mvqs4hctx4zfkono4rjejm2ta6gtyzkqxfjeily" }, "bar": { "/": "QmPJ4A6Su27ABvvduX78x2qdWMzkdAYxqeH5TVrHeo3xyy" } }' | /ipfs dag put
+            "bafyreidquig3arts3bmee53rutt463hdyu6ff4zeas2etf2h2oh4dfms44",
+            "a263626172d82a58230012200e317512b6f9f86e015a154cb97a9ddcdc7e372cccceb3947921634953c6537463666f6fd82a58250001711220354d455ff3a641b8cac25c38a77e64aa735dc8a48966a60f1a78caa172a4885e"
+        ),
+        (
+            // echo barfoo > file2 && ipfs add file2
+            "QmPJ4A6Su27ABvvduX78x2qdWMzkdAYxqeH5TVrHeo3xyy",
+            "0a0d08021207626172666f6f0a1807"
+        ),
+        (
+            // echo -n '{ "foo": { "/": "QmRgutAxd8t7oGkSm4wmeuByG6M51wcTso6cubDdQtuEfL" } }' | ipfs dag put
+            "bafyreibvjvcv745gig4mvqs4hctx4zfkono4rjejm2ta6gtyzkqxfjeily",
+            "a163666f6fd82a582300122031c3d57080d8463a3c63b2923df5a1d40ad7a73eae5a14af584213e5f504ac33"),
+        (
+            // echo foobar > file1 && ipfs add file1
+            "QmRgutAxd8t7oGkSm4wmeuByG6M51wcTso6cubDdQtuEfL",
+            "0a0d08021207666f6f6261720a1807"
+        ),
     ];
 
     for (cid_str, hex_str) in blocks.iter() {
         let cid = Cid::try_from(*cid_str).unwrap();
         let data = hex::decode(hex_str).unwrap();
 
-        println!("starting to process {:?}", cid_str);
+        validate(&cid, &data).unwrap();
+        decode_ipld(&cid, &data).unwrap();
 
-        libipld::block::decode_ipld(&cid, &data)
-            .unwrap_or_else(|e| panic!("failed to decode {:?} codec: {:?}: {:?}", cid_str, cid.codec(), e));
+        let block = Block {
+            cid,
+            data: data.into(),
+        };
 
-        println!("processed {:?} ok", cid_str);
-        let block = Block { cid, data: data.into() };
-
-        // TODO: it would probably be a good idea to rehash here not to get any copypaste mistakes
         ipfs.put_block(block).await.unwrap();
     }
 
     let root = Cid::try_from(blocks[0].0).unwrap();
 
-    let all_edges = edges(ipfs, root, None);
-
-    let all_edges: Result<Vec<_>, _> = all_edges.map_ok(|(source, dest)| (source.to_string(), dest.to_string())).try_collect().await;
-
-    let all_edges = all_edges.unwrap();
+    let all_edges: Vec<_> = edges(ipfs, root, None)
+        .map_ok(|(source, dest)| (source.to_string(), dest.to_string()))
+        .try_collect()
+        .await
+        .unwrap();
 
     let expected = [
-        ("bafyreidquig3arts3bmee53rutt463hdyu6ff4zeas2etf2h2oh4dfms44", "QmPJ4A6Su27ABvvduX78x2qdWMzkdAYxqeH5TVrHeo3xyy"),
-        ("bafyreidquig3arts3bmee53rutt463hdyu6ff4zeas2etf2h2oh4dfms44", "bafyreibvjvcv745gig4mvqs4hctx4zfkono4rjejm2ta6gtyzkqxfjeily"),
-        ("bafyreibvjvcv745gig4mvqs4hctx4zfkono4rjejm2ta6gtyzkqxfjeily", "QmRgutAxd8t7oGkSm4wmeuByG6M51wcTso6cubDdQtuEfL"),
+        (
+            "bafyreidquig3arts3bmee53rutt463hdyu6ff4zeas2etf2h2oh4dfms44",
+            "QmPJ4A6Su27ABvvduX78x2qdWMzkdAYxqeH5TVrHeo3xyy",
+        ),
+        (
+            "bafyreidquig3arts3bmee53rutt463hdyu6ff4zeas2etf2h2oh4dfms44",
+            "bafyreibvjvcv745gig4mvqs4hctx4zfkono4rjejm2ta6gtyzkqxfjeily",
+        ),
+        (
+            "bafyreibvjvcv745gig4mvqs4hctx4zfkono4rjejm2ta6gtyzkqxfjeily",
+            "QmRgutAxd8t7oGkSm4wmeuByG6M51wcTso6cubDdQtuEfL",
+        ),
     ];
 
-    let expected: Vec<_> = expected.iter()
+    let expected: Vec<_> = expected
+        .iter()
         .map(|(source, dest)| (String::from(*source), String::from(*dest)))
         .collect();
 

--- a/http/src/v0/refs.rs
+++ b/http/src/v0/refs.rs
@@ -13,15 +13,6 @@ use std::convert::TryFrom;
 use crate::v0::support::{with_ipfs, StringError};
 use serde::Deserialize;
 
-#[derive(Serialize, Debug)]
-struct RefsResponseItem {
-    #[serde(rename = "Err")]
-    err: String,
-
-    #[serde(rename = "Ref")]
-    refs: String,
-}
-
 mod options;
 use options::RefsOptions;
 
@@ -561,9 +552,9 @@ async fn inner_local<T: IpfsTypes>(ipfs: Ipfs<T>) -> Result<impl Reply, Rejectio
         .map_err(StringError::from)?
         .into_iter()
         .map(|cid| cid.to_string())
-        .map(|refs| RefsResponseItem {
-            refs,
-            err: "".to_string(),
+        .map(|refs| Edge {
+            ok: refs.into(),
+            err: "".into(),
         })
         .map(|response| {
             serde_json::to_string(&response)

--- a/http/src/v0/refs/format.rs
+++ b/http/src/v0/refs/format.rs
@@ -1,0 +1,194 @@
+use libipld::cid::Cid;
+use std::fmt;
+
+/// `EdgeFormatter` handles different kinds of formats that can be via the `format` query
+/// parameter. "Edge" is the unit produced by the stream of walking iplds links.
+#[derive(Debug)]
+pub enum EdgeFormatter {
+    /// The default: only the destination
+    Destination,
+    /// The default when `edges=true` on the query
+    Arrow,
+    /// Custom format string
+    FormatString(Vec<FormattedPart>),
+}
+
+/// Different parts of the format string
+#[derive(Debug, PartialEq, Eq)]
+pub enum FormattedPart {
+    Static(String),
+    Source,
+    Destination,
+    LinkName,
+}
+
+/// Failures to create new `EdgeFormatter`
+#[derive(Debug)]
+pub enum InvalidFormat<'a> {
+    /// This needs to be errored on as the combination would make no sense
+    EdgesWithCustomFormat,
+    /// The format string was invalid
+    Format(FormatError<'a>),
+}
+
+/// Failures to parse the `str` in `/api/v0/refs?format=str`.
+#[derive(Debug)]
+pub enum FormatError<'a> {
+    UnsupportedTag(&'a str),
+    UnterminatedTag(usize),
+}
+
+impl EdgeFormatter {
+    pub fn from_options<'a>(
+        edges: bool,
+        format: Option<&'a str>,
+    ) -> Result<Self, InvalidFormat<'a>> {
+        if edges && format.is_some() {
+            return Err(InvalidFormat::EdgesWithCustomFormat);
+        }
+
+        if edges {
+            Ok(EdgeFormatter::Arrow)
+        } else if let Some(formatstr) = format {
+            Ok(EdgeFormatter::FormatString(parse_format(formatstr)?))
+        } else {
+            Ok(EdgeFormatter::Destination)
+        }
+    }
+
+    /// Produces a `String` for the `Ref` property of returned `Edge` values, according to the
+    /// configured formatting. `link_name` is always `None` except for `dag-pb` nodes.
+    pub fn format(&self, src: Cid, dst: Cid, link_name: Option<String>) -> String {
+        match *self {
+            EdgeFormatter::Destination => dst.to_string(),
+            EdgeFormatter::Arrow => format!("{} -> {}", src, dst),
+            EdgeFormatter::FormatString(ref parts) => {
+                let mut out = String::new();
+                for part in parts {
+                    part.format(&mut out, &src, &dst, link_name.as_deref());
+                }
+                out.shrink_to_fit();
+                out
+            }
+        }
+    }
+}
+
+impl FormattedPart {
+    fn format(&self, out: &mut String, src: &Cid, dst: &Cid, linkname: Option<&str>) {
+        use fmt::Write;
+        use FormattedPart::*;
+        match *self {
+            Static(ref s) => out.push_str(s),
+            Source => write!(out, "{}", src).expect("String writing shouldn't fail"),
+            Destination => write!(out, "{}", dst).expect("String writing shouldn't fail"),
+            LinkName => {
+                if let Some(s) = linkname {
+                    out.push_str(s)
+                }
+            }
+        }
+    }
+}
+
+impl<'a> fmt::Display for InvalidFormat<'a> {
+    fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
+        use InvalidFormat::*;
+
+        match *self {
+            EdgesWithCustomFormat => write!(fmt, "using format argument with edges is not allowed"),
+            Format(ref e) => write!(fmt, "invalid format string: {}", e),
+        }
+    }
+}
+
+impl<'a> std::error::Error for InvalidFormat<'a> {}
+
+impl<'a> From<FormatError<'a>> for InvalidFormat<'a> {
+    fn from(e: FormatError<'a>) -> Self {
+        InvalidFormat::Format(e)
+    }
+}
+
+impl<'a> fmt::Display for FormatError<'a> {
+    fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
+        use FormatError::*;
+        match *self {
+            UnsupportedTag(tag) => write!(fmt, "unsupported tag: {:?}", tag),
+            UnterminatedTag(index) => write!(fmt, "unterminated tag at index: {}", index),
+        }
+    }
+}
+
+impl<'a> std::error::Error for FormatError<'a> {}
+
+fn parse_format(s: &str) -> Result<Vec<FormattedPart>, FormatError> {
+    use std::mem;
+
+    let mut buffer = String::new();
+    let mut ret = Vec::new();
+    let mut chars = s.char_indices();
+
+    loop {
+        match chars.next() {
+            Some((index, '<')) => {
+                if !buffer.is_empty() {
+                    ret.push(FormattedPart::Static(mem::take(&mut buffer)));
+                }
+
+                let remaining = chars.as_str();
+                let end = remaining
+                    .find('>')
+                    .ok_or_else(|| FormatError::UnterminatedTag(index))?;
+
+                // the use of string indices here is ok as the angle brackets are ascii and
+                // cannot be in the middle of multibyte char boundaries
+                let inside = &remaining[0..end];
+
+                // TODO: this might need to be case insensitive
+                let part = match inside {
+                    "src" => FormattedPart::Source,
+                    "dst" => FormattedPart::Destination,
+                    "linkname" => FormattedPart::LinkName,
+                    tag => return Err(FormatError::UnsupportedTag(tag)),
+                };
+
+                ret.push(part);
+
+                // the one here is to ignore the '>', which cannot be a codepoint boundary
+                chars = remaining[end + 1..].char_indices();
+            }
+            Some((_, ch)) => buffer.push(ch),
+            None => {
+                if !buffer.is_empty() {
+                    ret.push(FormattedPart::Static(buffer));
+                }
+                return Ok(ret);
+            }
+        }
+    }
+}
+
+#[test]
+fn parse_good_formats() {
+    use FormattedPart::*;
+
+    let examples = &[
+        (
+            "<linkname>: <src> -> <dst>",
+            vec![
+                LinkName,
+                Static(": ".into()),
+                Source,
+                Static(" -> ".into()),
+                Destination,
+            ],
+        ),
+        ("-<linkname>", vec![Static("-".into()), LinkName]),
+        ("<linkname>-", vec![LinkName, Static("-".into())]),
+    ];
+
+    for (input, expected) in examples {
+        assert_eq!(&parse_format(input).unwrap(), expected);
+    }
+}

--- a/http/src/v0/refs/options.rs
+++ b/http/src/v0/refs/options.rs
@@ -1,0 +1,143 @@
+use std::borrow::Cow;
+use std::convert::TryFrom;
+use std::fmt;
+
+#[derive(Debug)]
+pub struct RefsOptions {
+    /// This can start with /ipfs/ but doesn't have to, can continue with paths, if a link cannot
+    /// be found it's an json error from go-ipfs
+    pub arg: Vec<String>,
+    /// This can be used to format the output string into the `{ "Ref": "here" .. }`
+    pub format: Option<String>,
+    /// This cannot be used with `format`, prepends "source -> " to the `Ref` response
+    pub edges: bool,
+    /// Not sure if this is tested by conformance testing but I'd assume this destinatinos on their
+    /// first linking.
+    pub unique: bool,
+    pub recursive: bool,
+    // `int` in the docs apparently is platform specific
+    // go-ipfs only honors this when `recursive` is true.
+    // go-ipfs treats -2 as -1 when `recursive` is true.
+    // go-ipfs doesn't use the json return value if this value is too large or non-int
+    pub max_depth: Option<i64>,
+}
+
+impl RefsOptions {
+    pub fn max_depth(&self) -> Option<u64> {
+        if self.recursive {
+            match self.max_depth {
+                // zero means do nothing
+                Some(x) if x >= 0 => Some(x as u64),
+                _ => None,
+            }
+        } else {
+            // only immediate links after the path
+            Some(1)
+        }
+    }
+}
+
+#[derive(Debug)]
+pub enum ParseError<'a> {
+    DuplicateField(Cow<'a, str>),
+    MissingArg,
+    InvalidNumber(Cow<'a, str>, Cow<'a, str>),
+    InvalidBoolean(Cow<'a, str>, Cow<'a, str>),
+}
+
+impl<'a> fmt::Display for ParseError<'a> {
+    fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
+        use ParseError::*;
+        match *self {
+            DuplicateField(ref s) => write!(fmt, "field {:?} was duplicated", *s),
+            MissingArg => write!(fmt, "required field \"arg\" missing"),
+            InvalidNumber(ref k, ref v) => write!(fmt, "field {:?} invalid number: {:?}", *k, *v),
+            InvalidBoolean(ref k, ref v) => write!(fmt, "field {:?} invalid boolean: {:?}", *k, *v),
+        }
+    }
+}
+
+impl<'a> std::error::Error for ParseError<'a> {}
+
+impl<'a> TryFrom<&'a str> for RefsOptions {
+    type Error = ParseError<'a>;
+
+    fn try_from(q: &'a str) -> Result<Self, Self::Error> {
+        use ParseError::*;
+
+        // TODO: check how go-ipfs handles duplicate parameters for non-Vec fields
+        //
+        // this manual deserialization is required because `serde_urlencoded` (used by
+        // warp::query) does not support multiple instances of the same field, nor does
+        // `serde_qs` (it would support arg[]=...). supporting this in `serde_urlencoded` is
+        // out of scope; not sure of `serde_qs`.
+        let parse = url::form_urlencoded::parse(q.as_bytes());
+
+        let mut args = Vec::new();
+        let mut format = None;
+        let mut edges = None;
+        let mut unique = None;
+        let mut recursive = None;
+        let mut max_depth = None;
+
+        for (key, value) in parse {
+            let target = match &*key {
+                "arg" => {
+                    args.push(value.into_owned());
+                    continue;
+                }
+                "format" => {
+                    if format.is_none() {
+                        // not parsing this the whole way as there might be hope to have this
+                        // function removed in the future.
+                        format = Some(value.into_owned());
+                        continue;
+                    } else {
+                        return Err(DuplicateField(key));
+                    }
+                }
+                "max-depth" => {
+                    if max_depth.is_none() {
+                        max_depth = match value.parse::<i64>() {
+                            Ok(max_depth) => Some(max_depth),
+                            Err(_) => return Err(InvalidNumber(key, value)),
+                        };
+                        continue;
+                    } else {
+                        return Err(DuplicateField(key));
+                    }
+                }
+                "edges" => &mut edges,
+                "unique" => &mut unique,
+                "recursive" => &mut recursive,
+                _ => {
+                    // ignore unknown fields
+                    continue;
+                }
+            };
+
+            // common bool field handling
+            if target.is_none() {
+                match value.parse::<bool>() {
+                    Ok(value) => *target = Some(value),
+                    Err(_) => return Err(InvalidBoolean(key, value)),
+                }
+            } else {
+                return Err(DuplicateField(key));
+            }
+        }
+
+        if args.is_empty() {
+            return Err(MissingArg);
+        }
+
+        Ok(RefsOptions {
+            arg: args,
+            format,
+            edges: edges.unwrap_or(false),
+            unique: unique.unwrap_or(false),
+            recursive: recursive.unwrap_or(false),
+            max_depth,
+        })
+    }
+}

--- a/http/src/v0/refs/path.rs
+++ b/http/src/v0/refs/path.rs
@@ -391,4 +391,24 @@ mod tests {
             IpfsPath::try_from(bad).unwrap_err();
         }
     }
+
+    #[test]
+    fn trailing_slash_is_ignored() {
+        let paths = [
+            "/ipfs/QmdfTbBqBPQ7VNxZEYEj14VmRuZBkqFbiwReogJgS1zR1n/",
+            "QmdfTbBqBPQ7VNxZEYEj14VmRuZBkqFbiwReogJgS1zR1n/",
+        ];
+        for &path in &paths {
+            let p = IpfsPath::try_from(path).unwrap();
+            assert_eq!(p.len(), 0);
+        }
+    }
+
+    #[test]
+    fn multiple_slashes_are_deduplicated() {
+        // this is similar to behaviour in js-ipfs, as of
+        // https://github.com/ipfs-rust/rust-ipfs/pull/147/files#r408939850
+        let p = IpfsPath::try_from("/ipfs/QmdfTbBqBPQ7VNxZEYEj14VmRuZBkqFbiwReogJgS1zR1n///a").unwrap();
+        assert_eq!(p.len(), 1);
+    }
 }

--- a/http/src/v0/refs/path.rs
+++ b/http/src/v0/refs/path.rs
@@ -1,0 +1,328 @@
+//! Ipfs path handling following https://github.com/ipfs/go-path/. This rests under ipfs-http for
+//! now until it's ready to be moved to `rust-ipfs`. There is a competing implementation under
+//! `libipld` which might do almost the same things, but with different dependencies. This should
+//! be moving over to `ipfs` once we have seen that this works for `api/v0/dag/get` as well.
+//!
+//! Does not allow the root to be anything else than `/ipfs/` or missing at the moment.
+
+use libipld::cid::{self, Cid};
+use libipld::Ipld;
+use std::collections::BTreeMap;
+use std::convert::TryFrom;
+use std::fmt;
+
+#[derive(Debug)]
+pub enum PathError {
+    InvalidCid(cid::Error),
+    InvalidPath,
+}
+
+impl fmt::Display for PathError {
+    fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
+        match *self {
+            PathError::InvalidCid(e) => write!(fmt, "{}", e),
+            PathError::InvalidPath => write!(fmt, "invalid path"),
+        }
+    }
+}
+
+impl std::error::Error for PathError {}
+
+/// Ipfs path following https://github.com/ipfs/go-path/
+#[derive(Debug)]
+pub struct IpfsPath {
+    /// Option to support moving the cid
+    root: Option<Cid>,
+    path: std::vec::IntoIter<String>,
+}
+
+impl From<Cid> for IpfsPath {
+    /// Creates a new IpfsPath from just the Cid, which is the same as parsing from a string
+    /// representation of a Cid but cannot fail.
+    fn from(root: Cid) -> IpfsPath {
+        IpfsPath {
+            root: Some(root),
+            path: Vec::new().into_iter(),
+        }
+    }
+}
+
+impl TryFrom<&str> for IpfsPath {
+    type Error = PathError;
+
+    fn try_from(path: &str) -> Result<Self, Self::Error> {
+        let mut split = path.splitn(2, "/ipfs/");
+        let first = split.next();
+        let (_root, path) = match first {
+            Some("") => {
+                /* started with /ipfs/ */
+                if let Some(x) = split.next() {
+                    // was /ipfs/x
+                    ("ipfs", x)
+                } else {
+                    // just the /ipfs/
+                    return Err(PathError::InvalidPath);
+                }
+            }
+            Some(x) => {
+                /* maybe didn't start with /ipfs/, need to check second */
+                if split.next().is_some() {
+                    // x/ipfs/_
+                    return Err(PathError::InvalidPath);
+                }
+
+                ("", x)
+            }
+            None => return Err(PathError::InvalidPath),
+        };
+
+        let mut split = path.splitn(2, '/');
+        let root = split
+            .next()
+            .expect("first value from splitn(2, _) must exist");
+
+        let path = split
+            .next()
+            .iter()
+            .flat_map(|s| s.split('/').filter(|s| !s.is_empty()).map(String::from))
+            .collect::<Vec<_>>()
+            .into_iter();
+
+        let root = Some(Cid::try_from(root).map_err(PathError::InvalidCid)?);
+
+        Ok(IpfsPath { root, path })
+    }
+}
+
+impl IpfsPath {
+    pub fn take_root(&mut self) -> Option<Cid> {
+        self.root.take()
+    }
+
+    /// Walks the path depicted by self until either the path runs out or a new link needs to be
+    /// traversed to continue the walk. With !dag-pb documents this can result in subtree of an
+    /// Ipld be represented.
+    ///
+    /// # Panics
+    ///
+    /// If the current Ipld is from a dag-pb and the libipld has changed it's dag-pb tree structure.
+    pub fn walk(&mut self, current: &Cid, mut ipld: Ipld) -> Result<WalkSuccess, WalkFailed> {
+        if self.len() == 0 {
+            return Ok(WalkSuccess::EmptyPath(ipld));
+        }
+        for key in self {
+            if current.codec() == cid::Codec::DagProtobuf {
+                return walk_dagpb(ipld, key);
+            }
+
+            ipld = match ipld {
+                Ipld::Link(cid) if key == "." => {
+                    // go-ipfs: allows this to be skipped. lets require the dot for now.
+                    // FIXME: this would require the iterator to be peekable in addition.
+                    return Ok(WalkSuccess::Link(key, cid));
+                }
+                Ipld::Map(mut m) if m.contains_key(&key) => {
+                    if let Some(ipld) = m.remove(&key) {
+                        ipld
+                    } else {
+                        return Err(WalkFailed::UnmatchedMapProperty(m, key));
+                    }
+                }
+                Ipld::List(mut l) => {
+                    if let Ok(index) = key.parse::<usize>() {
+                        if index < l.len() {
+                            l.swap_remove(index)
+                        } else {
+                            return Err(WalkFailed::ListIndexOutOfRange(l, index));
+                        }
+                    } else {
+                        return Err(WalkFailed::UnparseableListIndex(l, key));
+                    }
+                }
+                x => return Err(WalkFailed::UnmatchableSegment(x, key)),
+            };
+
+            if let Ipld::Link(next_cid) = ipld {
+                return Ok(WalkSuccess::Link(key, next_cid));
+            }
+        }
+
+        Ok(WalkSuccess::AtDestination(ipld))
+    }
+
+    // Currently unused by commited code, but might become handy or easily removed later on.
+    #[allow(dead_code)]
+    pub fn debug<'a>(&'a self, current: &'a Cid) -> impl fmt::Debug + 'a {
+        struct DebuggableIpfsPath<'a> {
+            current: &'a Cid,
+            segments: &'a [String],
+        }
+
+        impl<'a> fmt::Debug for DebuggableIpfsPath<'a> {
+            fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
+                write!(fmt, "{}", self.current)?;
+                if !self.segments.is_empty() {
+                    write!(fmt, "/...")?;
+                }
+
+                for seg in self.segments {
+                    write!(fmt, "/{}", seg)?;
+                }
+                Ok(())
+            }
+        }
+
+        DebuggableIpfsPath {
+            current,
+            segments: self.path.as_slice(),
+        }
+    }
+}
+
+/// "Specialized" walk over dag-pb ipld tree.
+///
+/// # Panics
+///
+/// When the dag-pb ipld structure doesn't conform to expectations. This is to on purpose signal
+/// that we have gone out of sync with the libipld implementation.
+fn walk_dagpb(ipld: Ipld, key: String) -> Result<WalkSuccess, WalkFailed> {
+    // the current dag-pb represents the links of dag-pb nodes under "/Links"
+    // panicking instead of errors since we want to change this is dag-pb2ipld
+    // structure changes.
+
+    let (map, links) = match ipld {
+        Ipld::Map(mut m) => {
+            let links = m.remove("Links");
+            (m, links)
+        }
+        x => panic!(
+            "Expected dag-pb2ipld have top-level \"Links\", was: {:?}",
+            x
+        ),
+    };
+
+    let mut links = match links {
+        Some(Ipld::List(vec)) => vec,
+        Some(x) => panic!(
+            "Expected dag-pb2ipld top-level \"Links\" to be List, was: {:?}",
+            x
+        ),
+        // assume this means that the list was empty, and as such wasn't created
+        None => return Err(WalkFailed::UnmatchableSegment(Ipld::Map(map), key)),
+    };
+
+    let index = if let Ok(index) = key.parse::<usize>() {
+        if index >= links.len() {
+            return Err(WalkFailed::ListIndexOutOfRange(links, index));
+        }
+        index
+    } else {
+        let index = links
+            .iter()
+            .enumerate()
+            .position(|(i, link)| match link.get("Name") {
+                Some(Ipld::String(s)) => s == &key,
+                Some(x) => panic!(
+                    "Expected dag-pb2ipld \"Links[{}]/Name\" to be an optional String, was: {:?}",
+                    i, x
+                ),
+                None => false,
+            });
+
+        match index {
+            Some(index) => index,
+            None => return Err(WalkFailed::UnmatchableSegment(Ipld::List(links), key)),
+        }
+    };
+
+    let link = links.swap_remove(index);
+
+    match link {
+        Ipld::Map(mut m) => {
+            let link = match m.remove("Hash") {
+                Some(Ipld::Link(link)) => link,
+                Some(x) => panic!(
+                    "Expected dag-pb2ipld \"Links[{}]/Hash\" to be a link, was: {:?}",
+                    index, x
+                ),
+                None => panic!("Expected dag-pb2ipld \"Links[{}]/Hash\" to exist", index),
+            };
+
+            Ok(WalkSuccess::Link(key, link))
+        }
+        x => panic!(
+            "Expected dag-pb2ipld \"Links[{}]\" to be a Map, was: {:?}",
+            index, x
+        ),
+    }
+}
+
+/// The success values walking an `IpfsPath` can result to.
+pub enum WalkSuccess {
+    /// IpfsPath was already empty, or became empty during previous walk
+    EmptyPath(Ipld),
+    /// IpfsPath arrived at destination, following walk attempts will return EmptyPath
+    AtDestination(Ipld),
+    /// Path segment lead to a link which needs to be loaded to continue the walk
+    Link(String, Cid),
+}
+
+// FIXME: this probably needs to result in http 40x error? Currently converted to a stringerror
+// which is 500.
+#[derive(Debug)]
+pub enum WalkFailed {
+    /// Map key was not found
+    UnmatchedMapProperty(BTreeMap<String, Ipld>, String),
+    /// Segment could not be parsed as index
+    UnparseableListIndex(Vec<Ipld>, String),
+    /// Segment was out of range for the list
+    ListIndexOutOfRange(Vec<Ipld>, usize),
+    /// Catch-all failure for example when walking a segment on integer
+    UnmatchableSegment(Ipld, String),
+}
+
+impl fmt::Display for WalkFailed {
+    fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
+        match *self {
+            // go-ipfs: no such link found
+            WalkFailed::UnmatchedMapProperty(_, ref key) => {
+                write!(fmt, "No such link found: {:?}", key)
+            }
+            // go-ipfs: strconv.Atoi: parsing {:?}: invalid syntax
+            WalkFailed::UnparseableListIndex(_, ref segment) => {
+                write!(fmt, "Invalid list index: {:?}", segment)
+            }
+            // go-ipfs: array index out of range
+            WalkFailed::ListIndexOutOfRange(ref list, index) => write!(
+                fmt,
+                "List index out of range: the length is {} but the index is {}",
+                list.len(),
+                index
+            ),
+            // go-ipfs: tried to resolve through object that had no links
+            WalkFailed::UnmatchableSegment(_, _) => {
+                write!(fmt, "Tried to resolve through object that had no links")
+            }
+        }
+    }
+}
+
+impl std::error::Error for WalkFailed {}
+
+impl Iterator for IpfsPath {
+    type Item = String;
+
+    fn next(&mut self) -> Option<String> {
+        self.path.next()
+    }
+
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        self.path.size_hint()
+    }
+}
+
+impl ExactSizeIterator for IpfsPath {
+    fn len(&self) -> usize {
+        self.path.len()
+    }
+}

--- a/http/src/v0/refs/path.rs
+++ b/http/src/v0/refs/path.rs
@@ -326,3 +326,65 @@ impl ExactSizeIterator for IpfsPath {
         self.path.len()
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::IpfsPath;
+    use std::convert::TryFrom;
+
+    // good_paths, good_but_unsupported, bad_paths from https://github.com/ipfs/go-path/blob/master/path_test.go
+
+    #[test]
+    fn good_paths() {
+        let good = [
+            ("/ipfs/QmdfTbBqBPQ7VNxZEYEj14VmRuZBkqFbiwReogJgS1zR1n", 0),
+            ("/ipfs/QmdfTbBqBPQ7VNxZEYEj14VmRuZBkqFbiwReogJgS1zR1n/a", 1),
+            (
+                "/ipfs/QmdfTbBqBPQ7VNxZEYEj14VmRuZBkqFbiwReogJgS1zR1n/a/b/c/d/e/f",
+                6,
+            ),
+            (
+                "QmdfTbBqBPQ7VNxZEYEj14VmRuZBkqFbiwReogJgS1zR1n/a/b/c/d/e/f",
+                6,
+            ),
+            ("QmdfTbBqBPQ7VNxZEYEj14VmRuZBkqFbiwReogJgS1zR1n", 0),
+        ];
+
+        for &(good, len) in &good {
+            let p = IpfsPath::try_from(good).unwrap();
+            assert_eq!(p.len(), len);
+        }
+    }
+
+    #[test]
+    #[ignore]
+    fn good_but_unsupported() {
+        let _unsupported = [
+            "/ipld/QmdfTbBqBPQ7VNxZEYEj14VmRuZBkqFbiwReogJgS1zR1n",
+            "/ipld/QmdfTbBqBPQ7VNxZEYEj14VmRuZBkqFbiwReogJgS1zR1n/a",
+            "/ipld/QmdfTbBqBPQ7VNxZEYEj14VmRuZBkqFbiwReogJgS1zR1n/a/b/c/d/e/f",
+            "/ipns/QmdfTbBqBPQ7VNxZEYEj14VmRuZBkqFbiwReogJgS1zR1n/a/b/c/d/e/f",
+            "/ipns/QmdfTbBqBPQ7VNxZEYEj14VmRuZBkqFbiwReogJgS1zR1n",
+        ];
+    }
+
+    #[test]
+    fn bad_paths() {
+        let bad = [
+            "/QmdfTbBqBPQ7VNxZEYEj14VmRuZBkqFbiwReogJgS1zR1n",
+            "/QmdfTbBqBPQ7VNxZEYEj14VmRuZBkqFbiwReogJgS1zR1n/a",
+            "/ipfs/foo",
+            "/ipfs/",
+            "ipfs/",
+            "ipfs/QmdfTbBqBPQ7VNxZEYEj14VmRuZBkqFbiwReogJgS1zR1n",
+            "/ipld/foo",
+            "/ipld/",
+            "ipld/",
+            "ipld/QmdfTbBqBPQ7VNxZEYEj14VmRuZBkqFbiwReogJgS1zR1n",
+        ];
+
+        for &bad in &bad {
+            IpfsPath::try_from(bad).unwrap_err();
+        }
+    }
+}

--- a/http/src/v0/refs/path.rs
+++ b/http/src/v0/refs/path.rs
@@ -510,4 +510,55 @@ mod tests {
             p.walk(&doc_cid, example_doc.clone()).unwrap_err();
         }
     }
+
+    #[test]
+    fn walk_dagpb_links() {
+        // this is one of the links used by conformance tests
+        let payload = hex::decode(
+            "12330a2212206aad27d7e2fc815cd15bf679535062565dc927a831547281\
+            fc0af9e5d7e67c74120b6166726963616e2e747874180812340a221220fd\
+            36ac5279964db0cba8f7fa45f8c4c44ef5e2ff55da85936a378c96c9c632\
+            04120c616d6572696361732e747874180812360a2212207564c20415869d\
+            77a8a40ca68a9158e397dd48bdff1325cdb23c5bcd181acd17120e617573\
+            7472616c69616e2e7478741808",
+        )
+        .unwrap();
+        let cid = Cid::try_from("QmbrFTo4s6H23W6wmoZKQC2vSogGeQ4dYiceSqJddzrKVa").unwrap();
+
+        let decoded = libipld::block::decode_ipld(&cid, &payload).unwrap();
+
+        let paths = [
+            (
+                "QmbrFTo4s6H23W6wmoZKQC2vSogGeQ4dYiceSqJddzrKVa/african.txt",
+                "QmVX54jfjB8eRxLVxyQSod6b1FyDh7mR4mQie9j97i2Qk3",
+            ),
+            (
+                "QmbrFTo4s6H23W6wmoZKQC2vSogGeQ4dYiceSqJddzrKVa/americas.txt",
+                "QmfP6D9bRV4FEYDL4EHZtZG58kDwDfnzmyjuyK5d1pvzbM",
+            ),
+            (
+                "QmbrFTo4s6H23W6wmoZKQC2vSogGeQ4dYiceSqJddzrKVa/australian.txt",
+                "QmWEuXAjUGyndgr4MKqMBgzMW36XgPgvitt2jsXgtuc7JE",
+            ),
+        ];
+
+        for (path, link) in &paths {
+            let mut path = IpfsPath::try_from(*path).unwrap();
+            let target = Cid::try_from(*link).unwrap();
+
+            let doc_cid = path.take_root().unwrap();
+
+            // the dag-pb are walked by taking the names from the links, which makes for a bit
+            // ackward map reads and type hassle. the current walking code panicks if the structure
+            // isn't compatible so hopefully this test will allow us to catch issues with upgrading
+            // libipld early.
+            //
+            // there are still questionable parts, for example like matching links without a name.
+
+            match path.walk(&doc_cid, decoded.clone()).unwrap() {
+                WalkSuccess::Link(_, cid) => assert_eq!(cid, target),
+                x => panic!("unexpected result from walk: {:?}", x),
+            }
+        }
+    }
 }

--- a/http/src/v0/refs/path.rs
+++ b/http/src/v0/refs/path.rs
@@ -357,15 +357,19 @@ mod tests {
     }
 
     #[test]
-    #[ignore]
     fn good_but_unsupported() {
-        let _unsupported = [
+        let unsupported = [
             "/ipld/QmdfTbBqBPQ7VNxZEYEj14VmRuZBkqFbiwReogJgS1zR1n",
             "/ipld/QmdfTbBqBPQ7VNxZEYEj14VmRuZBkqFbiwReogJgS1zR1n/a",
             "/ipld/QmdfTbBqBPQ7VNxZEYEj14VmRuZBkqFbiwReogJgS1zR1n/a/b/c/d/e/f",
             "/ipns/QmdfTbBqBPQ7VNxZEYEj14VmRuZBkqFbiwReogJgS1zR1n/a/b/c/d/e/f",
             "/ipns/QmdfTbBqBPQ7VNxZEYEj14VmRuZBkqFbiwReogJgS1zR1n",
         ];
+
+        for &unsupported in &unsupported {
+            // these fail from failing to parse "ipld" or "ipns" as cid
+            IpfsPath::try_from(unsupported).unwrap_err();
+        }
     }
 
     #[test]

--- a/http/src/v0/refs/path.rs
+++ b/http/src/v0/refs/path.rs
@@ -479,6 +479,35 @@ mod tests {
     }
 
     #[test]
+    fn walk_link_with_dot() {
+        let cid = Cid::try_from("QmdfTbBqBPQ7VNxZEYEj14VmRuZBkqFbiwReogJgS1zR1n").unwrap();
+        let doc = ipld!(cid.clone());
+        let path = "bafyreielwgy762ox5ndmhx6kpi6go6il3gzahz3ngagb7xw3bj3aazeita/./foobar";
+
+        let mut p = IpfsPath::try_from(path).unwrap();
+        let doc_cid = p.take_root().unwrap();
+
+        assert_eq!(
+            p.walk(&doc_cid, doc),
+            Ok(WalkSuccess::Link(".".into(), cid))
+        );
+    }
+
+    #[test]
+    fn walk_link_without_dot_is_unsupported() {
+        let cid = Cid::try_from("QmdfTbBqBPQ7VNxZEYEj14VmRuZBkqFbiwReogJgS1zR1n").unwrap();
+        let doc = ipld!(cid.clone());
+        let path = "bafyreielwgy762ox5ndmhx6kpi6go6il3gzahz3ngagb7xw3bj3aazeita/foobar";
+
+        let mut p = IpfsPath::try_from(path).unwrap();
+        let doc_cid = p.take_root().unwrap();
+
+        // go-ipfs would walk over the link even without a dot, this will probably come up with
+        // dag/get
+        p.walk(&doc_cid, doc).unwrap_err();
+    }
+
+    #[test]
     fn good_walk_to_link() {
         let (example_doc, cid) = example_doc_and_a_cid();
 

--- a/http/src/v0/refs/path.rs
+++ b/http/src/v0/refs/path.rs
@@ -267,8 +267,8 @@ pub enum WalkSuccess {
     Link(String, Cid),
 }
 
-// FIXME: this probably needs to result in http 40x error? Currently converted to a stringerror
-// which is 500.
+/// These errors correspond to ones given out by go-ipfs 0.4.23 if the walk cannot be completed.
+/// go-ipfs reports these as 500 Internal Errors.
 #[derive(Debug)]
 pub enum WalkFailed {
     /// Map key was not found

--- a/http/src/v0/refs/support.rs
+++ b/http/src/v0/refs/support.rs
@@ -1,0 +1,33 @@
+use std::error::Error as StdError;
+use std::fmt;
+use warp::hyper::body::Bytes;
+use warp::hyper::Body;
+use warp::{reply::Response, Reply};
+
+use futures::stream::{TryStream, TryStreamExt};
+
+pub struct StreamResponse<S>(pub S);
+
+impl<S> Reply for StreamResponse<S>
+where
+    S: TryStream + Send + Sync + 'static,
+    S::Ok: Into<Bytes>,
+    S::Error: StdError + Send + Sync + 'static,
+{
+    fn into_response(self) -> Response {
+        Response::new(Body::wrap_stream(self.0.into_stream()))
+    }
+}
+
+/// Empty struct implementing std::error::Error, which we can use to mark the serde_json::Error as
+/// "handled" (by logging).
+#[derive(Debug)]
+pub struct HandledErr;
+
+impl StdError for HandledErr {}
+
+impl fmt::Display for HandledErr {
+    fn fmt(&self, _fmt: &mut fmt::Formatter) -> fmt::Result {
+        Ok(())
+    }
+}

--- a/http/src/v0/refs/unshared.rs
+++ b/http/src/v0/refs/unshared.rs
@@ -1,0 +1,51 @@
+use futures::stream::Stream;
+use pin_project::pin_project;
+use std::fmt;
+use std::{
+    pin::Pin,
+    task::{Context, Poll},
+};
+
+/// Copied from https://docs.rs/crate/async-compression/0.3.2/source/src/unshared.rs ... Did not
+/// keep the safety discussion comment because I am unsure if this is safe with the pinned
+/// projections.
+///
+/// The reason why this is needed is because `warp` or `hyper` needs it. `hyper` needs it because
+/// of compiler bug https://github.com/hyperium/hyper/issues/2159 and the future or stream we
+/// combine up with `async-stream` is not `Sync`, because the `async_trait` builds up a
+/// `Pin<Box<dyn std::future::Future<Output = _> + Send + '_>>`. The lifetime of those futures is
+/// not an issue, because at higher level (`refs_path`) those are within the owned values that
+/// method receives. It is unclear for me at least if the compiler is too strict with the `Sync`
+/// requirement which is derives for any reference or if the root cause here is that `hyper`
+/// suffers from that compiler issue.
+///
+/// Related: https://internals.rust-lang.org/t/what-shall-sync-mean-across-an-await/12020
+/// Related: https://github.com/dtolnay/async-trait/issues/77
+#[pin_project]
+pub struct Unshared<T> {
+    #[pin]
+    inner: T,
+}
+
+impl<T> Unshared<T> {
+    pub fn new(inner: T) -> Self {
+        Unshared { inner }
+    }
+}
+
+unsafe impl<T> Sync for Unshared<T> {}
+
+impl<T> fmt::Debug for Unshared<T> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct(core::any::type_name::<T>()).finish()
+    }
+}
+
+impl<S: Stream> Stream for Unshared<S> {
+    type Item = S::Item;
+
+    fn poll_next(self: Pin<&mut Self>, ctx: &mut Context) -> Poll<Option<Self::Item>> {
+        let this = self.project();
+        this.inner.poll_next(ctx)
+    }
+}

--- a/http/src/v0/support.rs
+++ b/http/src/v0/support.rs
@@ -116,6 +116,12 @@ impl<D: std::fmt::Display> From<D> for StringError {
     }
 }
 
+impl StringError {
+    pub fn new(cow: Cow<'static, str>) -> Self {
+        StringError(cow)
+    }
+}
+
 /// Common rejection handling strategy for ipfs http api compatible error responses
 pub async fn recover_as_message_response(
     err: warp::reject::Rejection,

--- a/http/src/v0/support.rs
+++ b/http/src/v0/support.rs
@@ -117,6 +117,8 @@ impl<D: std::fmt::Display> From<D> for StringError {
 }
 
 impl StringError {
+    // Allowing this as dead since it hopefully doesn't stay unused for long
+    #[allow(dead_code)]
     pub fn new(cow: Cow<'static, str>) -> Self {
         StringError(cow)
     }


### PR DESCRIPTION
Builds on #137 and later #155

TODO:

 - [x] fix rust-ipld cbor serde of cid values https://github.com/ipfs-rust/rust-ipld/pull/30
 - [x] refactor interface-ipfs-core `refs.js` to not use `ipfs.add` and `ipfs.object.put` https://github.com/ipfs/js-ipfs/pull/2972
 - [x] use all options
 - [x] bring back the dag path or separate it from the ipld::Store trait
 - [x] output streaming, formatting
 - [x] separate formatting (incl. format parsing)
 - [x] ~maybe figure out an abstraction for dag-pb2ipld traversal?~ just separated
 - [x] rebase
 - [x] port tests for ipfspath
 - [x] make refs.js order indepedent for dag-pb as well (https://github.com/ipfs/js-ipfs/pull/2982)
 - [x] split out the &mut removals into #155 
 - [x] rebase on top of #155
 - [x] add dag-pb test cases since the dag-pb handling is much of the lines

I'll be rebasing and probably separating the needless `mut` removal, which is probably a clippy issue why that wasn't picked up. Apparently the clippy or the compiler don't support linting on this at the moment.