### PR TITLE
fix: pin domain to specific revision

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -822,7 +822,7 @@ dependencies = [
 [[package]]
 name = "domain"
 version = "0.4.1"
-source = "git+https://github.com/nlnetlabs/domain#08496417cd2315970fdfb43201e619cac5e7a319"
+source = "git+https://github.com/nlnetlabs/domain?rev=084964#08496417cd2315970fdfb43201e619cac5e7a319"
 dependencies = [
  "domain-core",
  "domain-resolv",
@@ -831,7 +831,7 @@ dependencies = [
 [[package]]
 name = "domain-core"
 version = "0.4.1"
-source = "git+https://github.com/nlnetlabs/domain#08496417cd2315970fdfb43201e619cac5e7a319"
+source = "git+https://github.com/nlnetlabs/domain?rev=084964#08496417cd2315970fdfb43201e619cac5e7a319"
 dependencies = [
  "bytes 0.4.12",
  "chrono",
@@ -844,7 +844,7 @@ dependencies = [
 [[package]]
 name = "domain-resolv"
 version = "0.4.1"
-source = "git+https://github.com/nlnetlabs/domain#08496417cd2315970fdfb43201e619cac5e7a319"
+source = "git+https://github.com/nlnetlabs/domain?rev=084964#08496417cd2315970fdfb43201e619cac5e7a319"
 dependencies = [
  "domain-core",
  "futures 0.1.29",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ async-trait = "0.1.29"
 bitswap = { path = "bitswap" }
 byteorder = "1.3.4"
 dirs = "2.0.2"
-domain = { git = "https://github.com/nlnetlabs/domain", features = ["resolv"] }
+domain = { git = "https://github.com/nlnetlabs/domain", rev="084964", features = ["resolv"] }
 futures = { version = "0.3.4", features = ["compat", "io-compat"] }
 libipld = { git = "https://github.com/ipfs-rust/rust-ipld", features = ["dag-pb"] }
 libp2p = "0.16.2"


### PR DESCRIPTION
This PR pins the domain crate to a specific revision. domain has moved on quite a bit and when this 
I tried to use `rust-ipfs` as a crate in another project, I got this error: 

```
error: failed to select a version for `domain`.
    ... required by package `ipfs v0.1.0 (https://github.com/ipfs-rust/rust-ipfs#89e3f7c5)`
    ...

the package `ipfs` depends on `domain`, with features: `resolv` but `domain` does not have these features.

failed to select a version for `domain` which could resolve this conflict
```

I'd love to get it updated to at least `0.5.0` but I don't know exactly how much work that entails. It does indeed raise the importance of #75 