### PR TITLE
Refactor muts away, enhance ci builds

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -96,7 +96,7 @@ jobs:
 
     - name: Build
       if: matrix.platform.cross == false
-      run: cargo build --workspace
+      run: cargo build --workspace --tests --examples
 
     - name: Build android
       if: contains(matrix.platform.target, 'android')

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -96,16 +96,16 @@ jobs:
 
     - name: Build
       if: matrix.platform.cross == false
-      run: cargo build --workspace --tests --examples
+      run: cargo build --locked --workspace --tests --examples
 
     - name: Build android
       if: contains(matrix.platform.target, 'android')
-      run: cargo ndk --android-platform 29 --target ${{ matrix.platform.target }} build --workspace --exclude ipfs-http
+      run: cargo ndk --android-platform 29 --target ${{ matrix.platform.target }} build --locked --workspace --exclude ipfs-http
       # exclude http on android because openssl
 
     - name: Build other cross compilations
       if: contains(matrix.platform.target, 'android') == false && matrix.platform.cross == true
-      run: cargo build --workspace --exclude ipfs-http --target ${{ matrix.platform.target }}
+      run: cargo build --locked --workspace --exclude ipfs-http --target ${{ matrix.platform.target }}
       # exclude http on other cross compilation targets because openssl
 
     - name: Rust tests

--- a/examples/examples/ipfs_bitswap_test.rs
+++ b/examples/examples/ipfs_bitswap_test.rs
@@ -8,9 +8,11 @@ fn main() {
     env_logger::init();
     let options = IpfsOptions::<TestTypes>::default();
 
+    // Note: this test is now at rust-ipfs/tests/exchange_block.rs
+
     task::block_on(async move {
         // Start daemon and initialize repo
-        let (mut ipfs, fut) = UninitializedIpfs::new(options).await.start().await.unwrap();
+        let (ipfs, fut) = UninitializedIpfs::new(options).await.start().await.unwrap();
         task::spawn(fut);
 
         // Create a Block

--- a/http/src/v0/block.rs
+++ b/http/src/v0/block.rs
@@ -10,10 +10,7 @@ pub struct GetQuery {
     arg: String,
 }
 
-async fn get_query<T: IpfsTypes>(
-    ipfs: Ipfs<T>,
-    query: GetQuery,
-) -> Result<impl Reply, Rejection> {
+async fn get_query<T: IpfsTypes>(ipfs: Ipfs<T>, query: GetQuery) -> Result<impl Reply, Rejection> {
     let cid: Cid = query.arg.parse().map_err(StringError::from)?;
     let data = ipfs
         .get_block(&cid)
@@ -120,10 +117,7 @@ pub struct RmQuery {
 #[serde(rename_all = "PascalCase")]
 pub struct RmResponse {}
 
-async fn rm_query<T: IpfsTypes>(
-    ipfs: Ipfs<T>,
-    query: RmQuery,
-) -> Result<impl Reply, Rejection> {
+async fn rm_query<T: IpfsTypes>(ipfs: Ipfs<T>, query: RmQuery) -> Result<impl Reply, Rejection> {
     let cid: Cid = query.arg.parse().map_err(StringError::from)?;
     ipfs.remove_block(&cid).await.map_err(StringError::from)?;
     let response = RmResponse {};

--- a/http/src/v0/block.rs
+++ b/http/src/v0/block.rs
@@ -11,7 +11,7 @@ pub struct GetQuery {
 }
 
 async fn get_query<T: IpfsTypes>(
-    mut ipfs: Ipfs<T>,
+    ipfs: Ipfs<T>,
     query: GetQuery,
 ) -> Result<impl Reply, Rejection> {
     let cid: Cid = query.arg.parse().map_err(StringError::from)?;
@@ -49,7 +49,7 @@ pub struct PutResponse {
 }
 
 async fn put_query<T: IpfsTypes>(
-    mut ipfs: Ipfs<T>,
+    ipfs: Ipfs<T>,
     query: PutQuery,
     mut form: multipart::FormData,
 ) -> Result<impl Reply, Rejection> {
@@ -121,7 +121,7 @@ pub struct RmQuery {
 pub struct RmResponse {}
 
 async fn rm_query<T: IpfsTypes>(
-    mut ipfs: Ipfs<T>,
+    ipfs: Ipfs<T>,
     query: RmQuery,
 ) -> Result<impl Reply, Rejection> {
     let cid: Cid = query.arg.parse().map_err(StringError::from)?;
@@ -152,7 +152,7 @@ pub struct StatResponse {
 }
 
 async fn stat_query<T: IpfsTypes>(
-    mut ipfs: Ipfs<T>,
+    ipfs: Ipfs<T>,
     query: StatQuery,
 ) -> Result<impl Reply, Rejection> {
     let cid: Cid = query.arg.parse().map_err(StringError::from)?;

--- a/http/src/v0/dag.rs
+++ b/http/src/v0/dag.rs
@@ -13,7 +13,7 @@ pub struct PutQuery {
 }
 
 async fn put_query<T: IpfsTypes>(
-    mut ipfs: Ipfs<T>,
+    ipfs: Ipfs<T>,
     query: PutQuery,
     mut form: multipart::FormData,
 ) -> Result<impl Reply, Rejection> {

--- a/http/src/v0/refs.rs
+++ b/http/src/v0/refs.rs
@@ -76,7 +76,7 @@ mod tests {
 
         let options = IpfsOptions::inmemory_with_generated_keys(false);
 
-        let (mut ipfs, fut) = UninitializedIpfs::new(options).await.start().await.unwrap();
+        let (ipfs, fut) = UninitializedIpfs::new(options).await.start().await.unwrap();
         drop(fut);
 
         for data in &[b"1", b"2", b"3"] {

--- a/http/src/v0/refs.rs
+++ b/http/src/v0/refs.rs
@@ -37,10 +37,12 @@ async fn inner_local<T: IpfsTypes>(ipfs: Ipfs<T>) -> Result<impl Reply, Rejectio
             err: "".to_string(),
         })
         .map(|response| {
-            serde_json::to_string(&response).map_err(|e| {
-                eprintln!("error from serde_json: {}", e);
-                HandledErr
-            }).unwrap()
+            serde_json::to_string(&response)
+                .map_err(|e| {
+                    eprintln!("error from serde_json: {}", e);
+                    HandledErr
+                })
+                .unwrap()
         })
         .map(|ref_json| Ok(format!("{}{}", ref_json, "\n")))
         .collect();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -323,17 +323,17 @@ impl<Types: IpfsTypes> UninitializedIpfs<Types> {
 
 impl<Types: IpfsTypes> Ipfs<Types> {
     /// Puts a block into the ipfs repo.
-    pub async fn put_block(&mut self, block: Block) -> Result<Cid, Error> {
+    pub async fn put_block(&self, block: Block) -> Result<Cid, Error> {
         Ok(self.repo.put_block(block).await?.0)
     }
 
     /// Retrives a block from the ipfs repo.
-    pub async fn get_block(&mut self, cid: &Cid) -> Result<Block, Error> {
+    pub async fn get_block(&self, cid: &Cid) -> Result<Block, Error> {
         Ok(self.repo.get_block(cid).await?)
     }
 
     /// Remove block from the ipfs repo.
-    pub async fn remove_block(&mut self, cid: &Cid) -> Result<(), Error> {
+    pub async fn remove_block(&self, cid: &Cid) -> Result<(), Error> {
         Ok(self.repo.remove_block(cid).await?)
     }
 
@@ -793,7 +793,7 @@ mod tests {
         let cid = Cid::new_v1(Codec::Raw, Sha2_256::digest(&data));
         let block = Block::new(data, cid);
         let ipfs = UninitializedIpfs::new(options).await;
-        let (mut ipfs, fut) = ipfs.start().await.unwrap();
+        let (ipfs, fut) = ipfs.start().await.unwrap();
         task::spawn(fut);
 
         let cid: Cid = ipfs.put_block(block.clone()).await.unwrap();

--- a/tests/exchange_block.rs
+++ b/tests/exchange_block.rs
@@ -10,8 +10,8 @@ async fn exchange_block() {
     let data = b"hello block\n".to_vec().into_boxed_slice();
     let cid = Cid::new_v1(Codec::Raw, Sha2_256::digest(&data));
 
-    let mut a = Node::new(mdns).await;
-    let mut b = Node::new(mdns).await;
+    let a = Node::new(mdns).await;
+    let b = Node::new(mdns).await;
 
     let (_, mut addrs) = b.identity().await.unwrap();
 


### PR DESCRIPTION
* refactor away unnecessary `&mut self` from ipfs::Ipfs blockstore calls
* enable building of examples and tests in the same phase
* require `Cargo.lock` to be up to date `cargo build --locked`

This is split and extended from #147, where I'll be dropping the first commit soon-ish.