### PR TITLE
CI: Run clippy on whole workspace

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -134,7 +134,7 @@ jobs:
       run: cargo fmt --all -- --check
 
     - name: cargo clippy
-      run: cargo clippy -- -D warnings
+      run: cargo clippy --workspace --examples --tests -- -D warnings
 
   readme-doctest:
     runs-on: ubuntu-latest

--- a/http/src/v0/block.rs
+++ b/http/src/v0/block.rs
@@ -50,22 +50,14 @@ async fn put_query<T: IpfsTypes>(
     query: PutQuery,
     mut form: multipart::FormData,
 ) -> Result<impl Reply, Rejection> {
-    let format = match query
-        .format
-        .as_deref()
-        .unwrap_or("dag-pb")
-    {
+    let format = match query.format.as_deref().unwrap_or("dag-pb") {
         "dag-cbor" => Codec::DagCBOR,
         "dag-pb" => Codec::DagProtobuf,
         "dag-json" => Codec::DagJSON,
         "raw" => Codec::Raw,
         _ => return Err(StringError::from("unknown codec").into()),
     };
-    let hasher = match query
-        .mhtype
-        .as_deref()
-        .unwrap_or("sha2-256")
-    {
+    let hasher = match query.mhtype.as_deref().unwrap_or("sha2-256") {
         "sha2-256" => multihash::Sha2_256::digest,
         "sha2-512" => multihash::Sha2_512::digest,
         _ => return Err(StringError::from("unknown hash").into()),

--- a/http/src/v0/block.rs
+++ b/http/src/v0/block.rs
@@ -52,8 +52,7 @@ async fn put_query<T: IpfsTypes>(
 ) -> Result<impl Reply, Rejection> {
     let format = match query
         .format
-        .as_ref()
-        .map(|s| s.as_str())
+        .as_deref()
         .unwrap_or("dag-pb")
     {
         "dag-cbor" => Codec::DagCBOR,
@@ -64,8 +63,7 @@ async fn put_query<T: IpfsTypes>(
     };
     let hasher = match query
         .mhtype
-        .as_ref()
-        .map(|s| s.as_str())
+        .as_deref()
         .unwrap_or("sha2-256")
     {
         "sha2-256" => multihash::Sha2_256::digest,

--- a/http/src/v0/dag.rs
+++ b/http/src/v0/dag.rs
@@ -17,22 +17,14 @@ async fn put_query<T: IpfsTypes>(
     query: PutQuery,
     mut form: multipart::FormData,
 ) -> Result<impl Reply, Rejection> {
-    let format = match query
-        .format
-        .as_deref()
-        .unwrap_or("dag-cbor")
-    {
+    let format = match query.format.as_deref().unwrap_or("dag-cbor") {
         "dag-cbor" => Codec::DagCBOR,
         "dag-pb" => Codec::DagProtobuf,
         "dag-json" => Codec::DagJSON,
         "raw" => Codec::Raw,
         _ => return Err(StringError::from("unknown codec").into()),
     };
-    let hasher = match query
-        .hash_alg
-        .as_deref()
-        .unwrap_or("sha2-256")
-    {
+    let hasher = match query.hash_alg.as_deref().unwrap_or("sha2-256") {
         "sha2-256" => multihash::Sha2_256::digest,
         "sha2-512" => multihash::Sha2_512::digest,
         "sha3-512" => multihash::Sha3_512::digest,

--- a/http/src/v0/dag.rs
+++ b/http/src/v0/dag.rs
@@ -19,8 +19,7 @@ async fn put_query<T: IpfsTypes>(
 ) -> Result<impl Reply, Rejection> {
     let format = match query
         .format
-        .as_ref()
-        .map(|s| s.as_str())
+        .as_deref()
         .unwrap_or("dag-cbor")
     {
         "dag-cbor" => Codec::DagCBOR,
@@ -31,8 +30,7 @@ async fn put_query<T: IpfsTypes>(
     };
     let hasher = match query
         .hash_alg
-        .as_ref()
-        .map(|s| s.as_str())
+        .as_deref()
         .unwrap_or("sha2-256")
     {
         "sha2-256" => multihash::Sha2_256::digest,

--- a/src/p2p/swarm.rs
+++ b/src/p2p/swarm.rs
@@ -177,10 +177,10 @@ mod tests {
         env_logger::init();
 
         let (peer1_id, trans) = mk_transport();
-        let mut swarm1 = Swarm::new(trans, SwarmApi::new(), peer1_id.clone());
+        let mut swarm1 = Swarm::new(trans, SwarmApi::new(), peer1_id);
 
         let (peer2_id, trans) = mk_transport();
-        let mut swarm2 = Swarm::new(trans, SwarmApi::new(), peer2_id.clone());
+        let mut swarm2 = Swarm::new(trans, SwarmApi::new(), peer2_id);
 
         let (mut tx, mut rx) = mpsc::channel::<Multiaddr>(1);
         Swarm::listen_on(&mut swarm1, "/ip4/127.0.0.1/tcp/0".parse().unwrap()).unwrap();

--- a/src/repo/fs.rs
+++ b/src/repo/fs.rs
@@ -244,15 +244,14 @@ mod tests {
         let cid = Cid::new_v1(Codec::Raw, Sha2_256::digest(&data));
         let block = Block::new(data, cid.clone());
 
-        assert_eq!(store.init().await.unwrap(), ());
-        assert_eq!(store.open().await.unwrap(), ());
+        store.init().await.unwrap();
+        store.open().await.unwrap();
 
         let contains = store.contains(&cid);
         assert_eq!(contains.await.unwrap(), false);
         let get = store.get(&cid);
         assert_eq!(get.await.unwrap(), None);
-        let remove = store.remove(&cid);
-        assert_eq!(remove.await.unwrap(), ());
+        store.remove(&cid).await.unwrap();
 
         let put = store.put(block.clone());
         assert_eq!(put.await.unwrap().0, cid.to_owned());
@@ -261,8 +260,7 @@ mod tests {
         let get = store.get(&cid);
         assert_eq!(get.await.unwrap(), Some(block.clone()));
 
-        let remove = store.remove(&cid);
-        assert_eq!(remove.await.unwrap(), ());
+        store.remove(&cid).await.unwrap();
         let contains = store.contains(&cid);
         assert_eq!(contains.await.unwrap(), false);
         let get = store.get(&cid);
@@ -332,25 +330,22 @@ mod tests {
         let key = [1, 2, 3, 4];
         let value = [5, 6, 7, 8];
 
-        assert_eq!(store.init().await.unwrap(), ());
-        assert_eq!(store.open().await.unwrap(), ());
+        store.init().await.unwrap();
+        store.open().await.unwrap();
 
         let contains = store.contains(col, &key);
         assert_eq!(contains.await.unwrap(), false);
         let get = store.get(col, &key);
         assert_eq!(get.await.unwrap(), None);
-        let remove = store.remove(col, &key);
-        assert_eq!(remove.await.unwrap(), ());
+        store.remove(col, &key).await.unwrap();
 
-        let put = store.put(col, &key, &value);
-        assert_eq!(put.await.unwrap(), ());
+        store.put(col, &key, &value).await.unwrap();
         let contains = store.contains(col, &key);
         assert_eq!(contains.await.unwrap(), true);
         let get = store.get(col, &key);
         assert_eq!(get.await.unwrap(), Some(value.to_vec()));
 
-        let remove = store.remove(col, &key);
-        assert_eq!(remove.await.unwrap(), ());
+        store.remove(col, &key).await.unwrap();
         let contains = store.contains(col, &key);
         assert_eq!(contains.await.unwrap(), false);
         let get = store.get(col, &key);

--- a/src/repo/mem.rs
+++ b/src/repo/mem.rs
@@ -146,15 +146,14 @@ mod tests {
         let cid = Cid::new_v1(Codec::Raw, Sha2_256::digest(&data));
         let block = Block::new(data, cid.clone());
 
-        assert_eq!(store.init().await.unwrap(), ());
-        assert_eq!(store.open().await.unwrap(), ());
+        store.init().await.unwrap();
+        store.open().await.unwrap();
 
         let contains = store.contains(&cid);
         assert_eq!(contains.await.unwrap(), false);
         let get = store.get(&cid);
         assert_eq!(get.await.unwrap(), None);
-        let remove = store.remove(&cid);
-        assert_eq!(remove.await.unwrap(), ());
+        store.remove(&cid).await.unwrap();
 
         let put = store.put(block.clone());
         assert_eq!(put.await.unwrap().0, cid.to_owned());
@@ -163,8 +162,7 @@ mod tests {
         let get = store.get(&cid);
         assert_eq!(get.await.unwrap(), Some(block.clone()));
 
-        let remove = store.remove(&cid);
-        assert_eq!(remove.await.unwrap(), ());
+        store.remove(&cid).await.unwrap();
         let contains = store.contains(&cid);
         assert_eq!(contains.await.unwrap(), false);
         let get = store.get(&cid);
@@ -202,25 +200,23 @@ mod tests {
         let key = [1, 2, 3, 4];
         let value = [5, 6, 7, 8];
 
-        assert_eq!(store.init().await.unwrap(), ());
-        assert_eq!(store.open().await.unwrap(), ());
+        store.init().await.unwrap();
+        store.open().await.unwrap();
 
         let contains = store.contains(col, &key);
         assert_eq!(contains.await.unwrap(), false);
         let get = store.get(col, &key);
         assert_eq!(get.await.unwrap(), None);
-        let remove = store.remove(col, &key);
-        assert_eq!(remove.await.unwrap(), ());
+        store.remove(col, &key).await.unwrap();
 
         let put = store.put(col, &key, &value);
-        assert_eq!(put.await.unwrap(), ());
+        put.await.unwrap();
         let contains = store.contains(col, &key);
         assert_eq!(contains.await.unwrap(), true);
         let get = store.get(col, &key);
         assert_eq!(get.await.unwrap(), Some(value.to_vec()));
 
-        let remove = store.remove(col, &key);
-        assert_eq!(remove.await.unwrap(), ());
+        store.remove(col, &key).await.unwrap();
         let contains = store.contains(col, &key);
         assert_eq!(contains.await.unwrap(), false);
         let get = store.get(col, &key);

--- a/src/subscription.rs
+++ b/src/subscription.rs
@@ -266,7 +266,7 @@ mod tests {
         let s2 = registry.create_subscription(0);
 
         // make sure it timeouted but had time to register the waker
-        drop(s1.await.unwrap_err());
+        s1.await.unwrap_err();
 
         // this will cause a call to waker installed by s1, but it shouldn't be a problem.
         registry.finish_subscription(&0, 0);

--- a/tests/pubsub.rs
+++ b/tests/pubsub.rs
@@ -45,6 +45,7 @@ async fn can_publish_without_subscribing() {
 }
 
 #[async_std::test]
+#[allow(clippy::mutable_key_type)] // clippy doesn't like Vec inside HashSet
 async fn publish_between_two_nodes() {
     use futures::stream::StreamExt;
     use std::collections::HashSet;
@@ -84,7 +85,7 @@ async fn publish_between_two_nodes() {
         .cloned()
         .map(|(topics, id, data)| {
             (
-                topics.iter().map(|s| s.to_string()).collect::<Vec<_>>(),
+                topics.iter().map(|&s| s.to_string()).collect::<Vec<_>>(),
                 id.clone(),
                 data.to_vec(),
             )


### PR DESCRIPTION
I noticed we were running clippy only for the root crate in the workspace, excluding it's tests. This starts running it with `--workspace --examples --tests`.

I needed to allow that `clippy::mutable_key_type` for the tests. I don't think there's a way to fix the tests to work without ... Perhaps with rendering everything to string but perhaps that doesn't make much sense.