### PR TITLE
Add /dag/resolve endpoint

### DIFF
--- a/http/src/v0.rs
+++ b/http/src/v0.rs
@@ -45,7 +45,7 @@ where
             .or(warp::path!("bootstrap" / ..).and_then(not_implemented))
             .or(warp::path!("config" / ..).and_then(not_implemented))
             .or(dag::put(ipfs))
-            //.or(dag::get(ipfs))
+            .or(dag::resolve(ipfs))
             .or(warp::path!("dht" / ..).and_then(not_implemented))
             .or(warp::path!("get").and_then(not_implemented))
             .or(warp::path!("key" / ..).and_then(not_implemented))

--- a/http/src/v0/dag.rs
+++ b/http/src/v0/dag.rs
@@ -17,17 +17,20 @@ async fn put_query<T: IpfsTypes>(
     query: PutQuery,
     mut form: multipart::FormData,
 ) -> Result<impl Reply, Rejection> {
-    let format = match query.format.as_deref().unwrap_or("dag-cbor") {
-        "dag-cbor" => Codec::DagCBOR,
-        "dag-pb" => Codec::DagProtobuf,
-        "dag-json" => Codec::DagJSON,
-        "raw" => Codec::Raw,
+
+    use multihash::{Multihash, Sha2_256, Sha2_512, Sha3_512};
+
+    let (format, v0_fmt) = match query.format.as_deref().unwrap_or("dag-cbor") {
+        "dag-cbor" => (Codec::DagCBOR, false),
+        "dag-pb" => (Codec::DagProtobuf, true),
+        "dag-json" => (Codec::DagJSON, false),
+        "raw" => (Codec::Raw, false),
         _ => return Err(StringError::from("unknown codec").into()),
     };
-    let hasher = match query.hash.as_deref().unwrap_or("sha2-256") {
-        "sha2-256" => multihash::Sha2_256::digest,
-        "sha2-512" => multihash::Sha2_512::digest,
-        "sha3-512" => multihash::Sha3_512::digest,
+    let (hasher, v0_hash) = match query.hash.as_deref().unwrap_or("sha2-256") {
+        "sha2-256" => (Sha2_256::digest as fn(&[u8]) -> Multihash, true),
+        "sha2-512" => (Sha2_512::digest as fn(&[u8]) -> Multihash, false),
+        "sha3-512" => (Sha3_512::digest as fn(&[u8]) -> Multihash, false),
         _ => return Err(StringError::from("unknown hash").into()),
     };
     let mut buf = form
@@ -41,7 +44,13 @@ async fn put_query<T: IpfsTypes>(
         .map_err(|_| InvalidMultipartFormData)?;
     let data = buf.to_bytes().as_ref().to_vec().into_boxed_slice();
     let digest = hasher(&data);
-    let cid = Cid::new_v1(format, digest);
+    let cid = if v0_fmt && v0_hash {
+        // this is quite ugly way but apparently js-ipfs generates a v0 cid for this combination
+        // which is also created by go-ipfs
+        Cid::new_v0(digest).expect("cidv0 creation cannot fail for dag-pb and sha2-256")
+    } else {
+        Cid::new_v1(format, digest)
+    };
     let reply = json!({
         "Cid": { "/": cid.to_string() }
     });

--- a/http/src/v0/dag.rs
+++ b/http/src/v0/dag.rs
@@ -83,7 +83,9 @@ pub fn resolve<T: IpfsTypes>(
 #[derive(Debug, Deserialize)]
 struct ResolveOptions {
     arg: String,
-    cid_base: Option<String>,
+    // with local_resolve, we should not start to fetch the block ever, this is available in
+    // (js-)ipfs-http-client >= 44.0.0 and the last failing test.
+    // TODO: #[serde(rename = "localResolve")] local_resolve: bool
 }
 
 async fn inner_resolve<T: IpfsTypes>(

--- a/http/src/v0/refs.rs
+++ b/http/src/v0/refs.rs
@@ -19,7 +19,7 @@ mod format;
 use format::EdgeFormatter;
 
 mod path;
-use path::{IpfsPath, WalkSuccess};
+pub use path::{IpfsPath, WalkSuccess};
 
 mod unshared;
 use unshared::Unshared;
@@ -151,7 +151,10 @@ async fn refs_paths<T: IpfsTypes>(
 /// # Panics
 ///
 /// If there are dag-pb nodes and the libipld has changed it's dag-pb tree structure.
-async fn walk_path<T: IpfsTypes>(ipfs: &Ipfs<T>, mut path: IpfsPath) -> Result<(Cid, Ipld), Error> {
+pub async fn walk_path<T: IpfsTypes>(
+    ipfs: &Ipfs<T>,
+    mut path: IpfsPath,
+) -> Result<(Cid, Ipld), Error> {
     let mut current = path.take_root().unwrap();
 
     loop {

--- a/http/src/v0/refs/path.rs
+++ b/http/src/v0/refs/path.rs
@@ -150,6 +150,10 @@ impl IpfsPath {
         Ok(WalkSuccess::AtDestination(ipld))
     }
 
+    pub fn remaining_path(&self) -> &[String] {
+        self.path.as_slice()
+    }
+
     // Currently unused by commited code, but might become handy or easily removed later on.
     #[allow(dead_code)]
     pub fn debug<'a>(&'a self, current: &'a Cid) -> impl fmt::Debug + 'a {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -327,7 +327,8 @@ impl<Types: IpfsTypes> Ipfs<Types> {
         Ok(self.repo.put_block(block).await?.0)
     }
 
-    /// Retrives a block from the ipfs repo.
+    /// Retrieves a block from the local blockstore, or starts fetching from the network or join an
+    /// already started fetch.
     pub async fn get_block(&self, cid: &Cid) -> Result<Block, Error> {
         Ok(self.repo.get_block(cid).await?)
     }

--- a/src/repo/mod.rs
+++ b/src/repo/mod.rs
@@ -98,11 +98,18 @@ pub enum RepoEvent {
     UnprovideBlock(Cid),
 }
 
+/// Extension trait to easily upgrade owned values from possibly cidv0 to cidv1. The Cid version
+/// upgrade is done to support the "put as cidv0, get as cidv1" tests. The change is not
+/// communicated outside of the [`Repo`], as the "end user" doesn't need to know the Cid version
+/// may have been upgraded.
 trait CidUpgrade: Sized {
+    /// Returns the otherwise the equivalent value from `self` but with Cid version 1
     fn with_upgraded_cid(self) -> Self;
 }
 
+/// Extension trait similar to [`CidUpgrade`] but for non-owned types.
 trait CidUpgradedRef: Sized {
+    /// Returns the otherwise the equivalent value from `&self` but with Cid version 1
     fn as_upgraded_cid(&self) -> Self;
 }
 


### PR DESCRIPTION
The first commit is a bugfix, should probably make that into a interface-http-core test case.

TODO:

 - [x] pass easiest tests
 - [x] ~add "get local block" api to `Ipfs`~ this wasn't needed nor is it accessible without js-ipfs-http-client 44.0.0 which will also not send content-length headers anymore so it'll break all multipart functions...
 - [x] pass rest of the tests except cidv0<->cidv1
 - [x] ~continue cidv0<->cidv1 on another PR~ well it wasn't so difficult
