### PR TITLE
refactor: remove clippy warnings

### DIFF
--- a/http/src/v0/refs/format.rs
+++ b/http/src/v0/refs/format.rs
@@ -39,10 +39,10 @@ pub enum FormatError<'a> {
 }
 
 impl EdgeFormatter {
-    pub fn from_options<'a>(
+    pub fn from_options(
         edges: bool,
-        format: Option<&'a str>,
-    ) -> Result<Self, InvalidFormat<'a>> {
+        format: Option<&str>,
+    ) -> Result<Self, InvalidFormat> {
         if edges && format.is_some() {
             return Err(InvalidFormat::EdgesWithCustomFormat);
         }

--- a/http/src/v0/refs/format.rs
+++ b/http/src/v0/refs/format.rs
@@ -39,10 +39,7 @@ pub enum FormatError<'a> {
 }
 
 impl EdgeFormatter {
-    pub fn from_options(
-        edges: bool,
-        format: Option<&str>,
-    ) -> Result<Self, InvalidFormat> {
+    pub fn from_options(edges: bool, format: Option<&str>) -> Result<Self, InvalidFormat> {
         if edges && format.is_some() {
             return Err(InvalidFormat::EdgesWithCustomFormat);
         }

--- a/http/src/v0/refs/path.rs
+++ b/http/src/v0/refs/path.rs
@@ -496,7 +496,7 @@ mod tests {
     #[test]
     fn walk_link_without_dot_is_unsupported() {
         let cid = Cid::try_from("QmdfTbBqBPQ7VNxZEYEj14VmRuZBkqFbiwReogJgS1zR1n").unwrap();
-        let doc = ipld!(cid.clone());
+        let doc = ipld!(cid);
         let path = "bafyreielwgy762ox5ndmhx6kpi6go6il3gzahz3ngagb7xw3bj3aazeita/foobar";
 
         let mut p = IpfsPath::try_from(path).unwrap();


### PR DESCRIPTION
it is quite difficult to remember the --workspace --tests parameters.. I messed up by merging first 147, then not rebuilding completly before merging the following two. bors would be nice :)