### PR TITLE
fix: minor block/rm bug

### DIFF
--- a/http/src/v0/block.rs
+++ b/http/src/v0/block.rs
@@ -171,12 +171,12 @@ async fn rm_query<T: IpfsTypes>(
                 if force {
                     RmResponse {
                         hash: cid.to_string(),
-                        error: e.to_string(),
+                        error: "".to_string(),
                     }
                 } else {
                     RmResponse {
                         hash: cid.to_string(),
-                        error: "".to_string(),
+                        error: e.to_string(),
                     }
                 }
             }

--- a/http/src/v0/refs.rs
+++ b/http/src/v0/refs.rs
@@ -364,14 +364,6 @@ async fn inner_local<T: IpfsTypes>(ipfs: Ipfs<T>) -> Result<impl Reply, Rejectio
         .await
         .map_err(StringError::from)?
         .into_iter()
-        .map(|cid| {
-            if cid.version() != cid::Version::V0 {
-                Cid::new_v0(cid.hash().to_owned())
-            } else {
-                Ok(cid)
-            }
-        })
-        .map(|cid| cid.unwrap())
         .map(|cid| cid.to_string())
         .map(|refs| Edge {
             ok: refs.into(),

--- a/http/src/v0/refs.rs
+++ b/http/src/v0/refs.rs
@@ -364,6 +364,14 @@ async fn inner_local<T: IpfsTypes>(ipfs: Ipfs<T>) -> Result<impl Reply, Rejectio
         .await
         .map_err(StringError::from)?
         .into_iter()
+        .map(|cid| {
+            if cid.version() != cid::Version::V0 {
+                Cid::new_v0(cid.hash().to_owned())
+            } else {
+                Ok(cid)
+            }
+        })
+        .map(|cid| cid.unwrap())
         .map(|cid| cid.to_string())
         .map(|refs| Edge {
             ok: refs.into(),


### PR DESCRIPTION
This PR fixes two minor bugs found while doing final 1.2 conformance testing:
1. ~Refs local wants the results to be returned as `Qm***` multihashes~
2. Block rm had a minor typo-related bug, switched two lines.

Edit: only the block rm fix now