### PR TITLE
fix: decrease ipfs-http compilation times 50%

### DIFF
--- a/http/src/v0.rs
+++ b/http/src/v0.rs
@@ -1,5 +1,6 @@
 use ipfs::{Ipfs, IpfsTypes};
 use std::convert::Infallible;
+use warp::{query, Filter};
 
 pub mod bitswap;
 pub mod block;
@@ -14,64 +15,86 @@ pub mod support;
 pub use support::recover_as_message_response;
 pub(crate) use support::{with_ipfs, InvalidPeerId, NotImplemented, StringError};
 
-pub fn routes<T>(
+/// Helper to combine the multiple filters together with Filter::or, possibly boxing the types in
+/// the process. This greatly helps the build times for `ipfs-http`.
+macro_rules! combine {
+    ($x:expr, $($y:expr),+) => {
+        {
+            let filter = boxed_on_debug!($x);
+            $(
+                let filter = boxed_on_debug!(filter.or($y));
+            )+
+            filter
+        }
+    }
+}
+
+#[cfg(debug_assertions)]
+macro_rules! boxed_on_debug {
+    ($x:expr) => {
+        $x.boxed()
+    };
+}
+
+#[cfg(not(debug_assertions))]
+macro_rules! boxed_on_debug {
+    ($x:expr) => {
+        $x
+    };
+}
+
+pub fn routes<T: IpfsTypes>(
     ipfs: &Ipfs<T>,
     shutdown_tx: tokio::sync::mpsc::Sender<()>,
-) -> impl warp::Filter<Extract = impl warp::Reply, Error = Infallible> + Clone
-where
-    T: IpfsTypes,
-{
-    use warp::{query, Filter};
-    // /api/v0/shutdown
+) -> impl warp::Filter<Extract = impl warp::Reply, Error = Infallible> + Clone {
+    let mount = warp::path("api").and(warp::path("v0"));
+
     let shutdown = warp::post()
         .and(warp::path!("shutdown"))
         .and(warp::any().map(move || shutdown_tx.clone()))
         .and_then(handle_shutdown);
 
-    let mount = warp::path("api").and(warp::path("v0"));
+    let api = mount.and(combine!(
+        shutdown,
+        id::identity(ipfs),
+        warp::path!("add").and_then(not_implemented),
+        bitswap::wantlist(ipfs),
+        bitswap::stat(ipfs),
+        block::get(ipfs),
+        block::put(ipfs),
+        block::rm(ipfs),
+        block::stat(ipfs),
+        warp::path!("bootstrap" / ..).and_then(not_implemented),
+        warp::path!("config" / ..).and_then(not_implemented),
+        dag::put(ipfs),
+        dag::resolve(ipfs),
+        warp::path!("dht" / ..).and_then(not_implemented),
+        warp::path!("get").and_then(not_implemented),
+        warp::path!("key" / ..).and_then(not_implemented),
+        warp::path!("name" / ..).and_then(not_implemented),
+        warp::path!("object" / ..).and_then(not_implemented),
+        warp::path!("pin" / ..).and_then(not_implemented),
+        warp::path!("ping" / ..).and_then(not_implemented),
+        pubsub::routes(ipfs),
+        refs::local(ipfs),
+        refs::refs(ipfs),
+        warp::path!("repo" / ..).and_then(not_implemented),
+        warp::path!("stats" / ..).and_then(not_implemented),
+        swarm::connect(ipfs),
+        swarm::peers(ipfs),
+        swarm::addrs(ipfs),
+        swarm::addrs_local(ipfs),
+        swarm::disconnect(ipfs),
+        warp::path!("version")
+            .and(query::<version::Query>())
+            .and_then(version::version)
+    ));
 
-    let api = mount.and(
-        shutdown
-            .or(id::identity(ipfs))
-            // Placeholder paths
-            // https://docs.rs/warp/0.2.2/warp/macro.path.html#path-prefixes
-            .or(warp::path!("add").and_then(not_implemented))
-            .or(bitswap::wantlist(ipfs))
-            .or(bitswap::stat(ipfs))
-            .or(block::get(ipfs))
-            .or(block::put(ipfs))
-            .or(block::rm(ipfs))
-            .or(block::stat(ipfs))
-            .or(warp::path!("bootstrap" / ..).and_then(not_implemented))
-            .or(warp::path!("config" / ..).and_then(not_implemented))
-            .or(dag::put(ipfs))
-            .or(dag::resolve(ipfs))
-            .or(warp::path!("dht" / ..).and_then(not_implemented))
-            .or(warp::path!("get").and_then(not_implemented))
-            .or(warp::path!("key" / ..).and_then(not_implemented))
-            .or(warp::path!("name" / ..).and_then(not_implemented))
-            .or(warp::path!("object" / ..).and_then(not_implemented))
-            .or(warp::path!("pin" / ..).and_then(not_implemented))
-            .or(warp::path!("ping" / ..).and_then(not_implemented))
-            .or(pubsub::routes(ipfs))
-            .or(refs::local(ipfs))
-            .or(refs::refs(ipfs))
-            .or(warp::path!("repo" / ..).and_then(not_implemented))
-            .or(warp::path!("stats" / ..).and_then(not_implemented))
-            .or(swarm::connect(ipfs))
-            .or(swarm::peers(ipfs))
-            .or(swarm::addrs(ipfs))
-            .or(swarm::addrs_local(ipfs))
-            .or(swarm::disconnect(ipfs))
-            .or(warp::path!("version")
-                .and(query::<version::Query>())
-                .and_then(version::version)),
-    );
-
+    // have a common handler turn the rejections into 400 or 500 with json body
     api.recover(recover_as_message_response)
 }
 
-pub async fn handle_shutdown(
+pub(crate) async fn handle_shutdown(
     mut tx: tokio::sync::mpsc::Sender<()>,
 ) -> Result<impl warp::Reply, std::convert::Infallible> {
     Ok(match tx.send(()).await {


### PR DESCRIPTION
by boxing the filters on debug builds. Note: the 50% is for me in clean builds, down from 5 minutes to about 2 minutes. Incremental builds are less than 30s depending on the change.